### PR TITLE
Allow to use DefaultAsyncClient 

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
+++ b/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
@@ -26,7 +26,7 @@ public abstract class AbstractConnection extends Task implements AbstractConnect
 
     protected String endpointOverride;
 
-    private Boolean useDefaultAsyncClient;
+    private Boolean compatibilityMode;
 
     protected AwsCredentialsProvider credentials(RunContext runContext) throws IllegalVariableEvaluationException {
         String accessKeyId = runContext.render(this.accessKeyId);

--- a/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
+++ b/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
@@ -26,6 +26,8 @@ public abstract class AbstractConnection extends Task implements AbstractConnect
 
     protected String endpointOverride;
 
+    private Boolean useDefaultAsyncClient;
+
     protected AwsCredentialsProvider credentials(RunContext runContext) throws IllegalVariableEvaluationException {
         String accessKeyId = runContext.render(this.accessKeyId);
         String secretKeyId = runContext.render(this.secretKeyId);

--- a/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
@@ -19,7 +19,7 @@ import java.net.URI;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-public abstract class AbstractS3 extends AbstractConnection  {
+public abstract class AbstractS3 extends AbstractConnection {
 
     protected S3Client client(RunContext runContext) throws IllegalVariableEvaluationException {
         S3ClientBuilder s3ClientBuilder = S3Client.builder()
@@ -36,18 +36,36 @@ public abstract class AbstractS3 extends AbstractConnection  {
 
         return s3ClientBuilder.build();
     }
+
     protected S3AsyncClient asyncClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        S3CrtAsyncClientBuilder s3ClientBuilder = S3AsyncClient.crtBuilder()
-            .credentialsProvider(this.credentials(runContext));
 
-        if (this.region != null) {
-            s3ClientBuilder.region(Region.of(runContext.render(this.region)));
+        if (this.getUseDefaultAsyncClient()) {
+            S3AsyncClientBuilder s3ClientBuilder = S3AsyncClient.builder()
+                .credentialsProvider(this.credentials(runContext));
+
+            if (this.region != null) {
+                s3ClientBuilder.region(Region.of(runContext.render(this.region)));
+            }
+
+            if (this.endpointOverride != null) {
+                s3ClientBuilder.endpointOverride(URI.create(runContext.render(this.endpointOverride)));
+            }
+            return s3ClientBuilder.build();
+
+        } else {
+            S3CrtAsyncClientBuilder s3ClientBuilder = S3AsyncClient.crtBuilder()
+                .credentialsProvider(this.credentials(runContext));
+
+            if (this.region != null) {
+                s3ClientBuilder.region(Region.of(runContext.render(this.region)));
+            }
+
+            if (this.endpointOverride != null) {
+                s3ClientBuilder.endpointOverride(URI.create(runContext.render(this.endpointOverride)));
+            }
+
+            return s3ClientBuilder.build();
         }
 
-        if (this.endpointOverride != null) {
-            s3ClientBuilder.endpointOverride(URI.create(runContext.render(this.endpointOverride)));
-        }
-
-        return s3ClientBuilder.build();
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
@@ -39,7 +39,7 @@ public abstract class AbstractS3 extends AbstractConnection {
 
     protected S3AsyncClient asyncClient(RunContext runContext) throws IllegalVariableEvaluationException {
 
-        if (this.getUseDefaultAsyncClient()) {
+        if (this.getCompatibilityMode()) {
             S3AsyncClientBuilder s3ClientBuilder = S3AsyncClient.builder()
                 .credentialsProvider(this.credentials(runContext));
 

--- a/src/main/java/io/kestra/plugin/aws/s3/Download.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Download.java
@@ -52,11 +52,11 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
     protected String versionId;
 
     @Schema(
-        title = "Use the default S3AsyncClientBuilder client to upload files."
+        title = "this property will use the AsynS3Client instead of the S3CrtAsynClient which maximize compatibility with S3-compatible services but restrict uploads and downloads to 2GB"
     )
     @PluginProperty
     @Builder.Default
-    private Boolean useDefaultAsyncClient = false;
+    private Boolean compatibilityMode = false;
 
     @Override
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/aws/s3/Download.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Download.java
@@ -6,10 +6,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -53,6 +50,13 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
     )
     @PluginProperty(dynamic = true)
     protected String versionId;
+
+    @Schema(
+        title = "Use the default S3AsyncClientBuilder client to upload files."
+    )
+    @PluginProperty
+    @Builder.Default
+    private Boolean useDefaultAsyncClient = false;
 
     @Override
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.aws.s3;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.aws.s3.models.S3Object;
@@ -50,6 +51,14 @@ public class Downloads extends AbstractS3Object implements RunnableTask<List.Out
 
     @Builder.Default
     private Integer maxKeys = 1000;
+
+    @Schema(
+        title = "Use the default S3AsyncClientBuilder client to upload files."
+    )
+    @PluginProperty
+    @Builder.Default
+    private Boolean useDefaultAsyncClient = false;
+
 
     private String expectedBucketOwner;
 

--- a/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
@@ -53,11 +53,11 @@ public class Downloads extends AbstractS3Object implements RunnableTask<List.Out
     private Integer maxKeys = 1000;
 
     @Schema(
-        title = "Use the default S3AsyncClientBuilder client to upload files."
+        title = "this property will use the AsynS3Client instead of the S3CrtAsynClient which maximize compatibility with S3-compatible services but restrict uploads and downloads to 2GB"
     )
     @PluginProperty
     @Builder.Default
-    private Boolean useDefaultAsyncClient = false;
+    private Boolean compatibilityMode = false;
 
 
     private String expectedBucketOwner;

--- a/src/main/java/io/kestra/plugin/aws/s3/Upload.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Upload.java
@@ -64,11 +64,11 @@ public class Upload extends AbstractS3Object implements RunnableTask<Upload.Outp
     private Map<String, String> metadata;
 
     @Schema(
-        title = "Use the default S3AsyncClientBuilder client to upload files."
+        title = "this property will use the AsynS3Client instead of the S3CrtAsynClient which maximize compatibility with S3-compatible services but restrict uploads and downloads to 2GB"
     )
     @PluginProperty
     @Builder.Default
-    private Boolean useDefaultAsyncClient = false;
+    private Boolean compatibilityMode = false;
 
     @Schema(
         title = "If you don't specify, S3 Standard is the default storage class. Amazon S3 supports other storage classes."

--- a/src/main/java/io/kestra/plugin/aws/s3/Upload.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Upload.java
@@ -7,16 +7,12 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.CompletedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
@@ -68,6 +64,13 @@ public class Upload extends AbstractS3Object implements RunnableTask<Upload.Outp
     private Map<String, String> metadata;
 
     @Schema(
+        title = "Use the default S3AsyncClientBuilder client to upload files."
+    )
+    @PluginProperty
+    @Builder.Default
+    private Boolean useDefaultAsyncClient = false;
+
+    @Schema(
         title = "If you don't specify, S3 Standard is the default storage class. Amazon S3 supports other storage classes."
     )
     @PluginProperty(dynamic = true)
@@ -79,6 +82,7 @@ public class Upload extends AbstractS3Object implements RunnableTask<Upload.Outp
         String key = runContext.render(this.key);
 
         try (S3AsyncClient client = this.asyncClient(runContext)) {
+
             File tempFile = runContext.tempFile().toFile();
             URI from = new URI(runContext.render(this.from));
             Files.copy(runContext.uriToInputStream(from), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
Add configuration to use S3 AWS DefaultAsyncClient and support CEPH BucketStorage.

This PR https://github.com/kestra-io/plugin-aws/pull/70/files change the S3Client to S3CrtAsyncClient, but create regression with CEPH object storage.

In : software/amazon/awssdk/transfer/s3/S3TransferManager.java we found the correct way to create multipart upload and fix https://github.com/kestra-io/plugin-aws/issues/69
```
         * It's highly recommended to use {@link S3AsyncClient#crtBuilder()} to create an {@link S3AsyncClient} instance to
         * benefit from multipart upload/download feature and maximum throughput.
```

but this creates regression with more traditional ObjectStorage solutions because checksum, retry policy and signer are disabled because they are handled in crt

found in : software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java 
```
    private static S3AsyncClient initializeS3AsyncClient(DefaultS3CrtClientBuilder builder) {
        ClientOverrideConfiguration.Builder overrideConfigurationBuilder =
            ClientOverrideConfiguration.builder()
                                       // Disable checksum, retry policy and signer because they are handled in crt
                                       .putAdvancedOption(SdkAdvancedClientOption.SIGNER, new NoOpSigner())
                                       .putExecutionAttribute(SdkExecutionAttribute.HTTP_RESPONSE_CHECKSUM_VALIDATION,
                                                              ChecksumValidation.FORCE_SKIP)
                                       .retryPolicy(RetryPolicy.none())
                                       .addExecutionInterceptor(new ValidateRequestInterceptor())
                                       .addExecutionInterceptor(new AttachHttpAttributesExecutionInterceptor());

        if (builder.executionInterceptors != null) {
            builder.executionInterceptors.forEach(overrideConfigurationBuilder::addExecutionInterceptor);
        }

```

Workaround is to add a @PluginProperty configuration and force to use DefaultAsyncClient rather than CrtAsyncClient.

But be careful, with DefaultAsyncClient you don't have have multipart upload fix , you will not be able to upload very large files.  If you need it, maybe disable see something like : checksumValidationEnabled() or verify your object storage understand the header `x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER` 


