### PR TITLE
fix(example): correct the task example for AWS Kinesis

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/kinesis/PutRecords.java
+++ b/src/main/java/io/kestra/plugin/aws/kinesis/PutRecords.java
@@ -57,6 +57,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                 "records:",
                 "  - data: \"user sign-in event\"",
                 "    explicitHashKey: \"optional hash value overriding the partition key\"",
+                "    partitionKey: \"user1\"",
                 "  - data: \"user sign-out event\"",
                 "    partitionKey: \"user1\""
             }
@@ -68,7 +69,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                 "secretKeyId: \"<secret-key>\"",
                 "region: \"eu-central-1\"",
                 "streamName: \"mystream\"",
-                "records: kestra://myfile.ion"
+                "records: kestra:///myfile.ion"
             }
         )
     }


### PR DESCRIPTION
1. partitionKey is mandatory in the record.
2. Kestra URI contains 3 slashes `kestra:///`. 