### PR TITLE
feat(aws-s3) Refactor the Download task to add multiple files download capability

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/s3/Download.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Download.java
@@ -190,6 +190,7 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
                     .contentLength(download.getLeft().contentLength())
                     .contentType(download.getLeft().contentType())
                     .metadata(download.getLeft().metadata())
+                    .eTag(download.getLeft().eTag())
                     .versionId(download.getLeft().versionId())
                     .build());
             }

--- a/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
@@ -1,0 +1,37 @@
+package io.kestra.plugin.aws.s3.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.net.URI;
+import java.util.Map;
+
+@Builder
+@Getter
+public class FileInfo {
+    @Schema(
+        title = "The URI of the downloaded file in Kestra's storage"
+    )
+    private URI uri;
+
+    @Schema(
+        title = "The size of the file in bytes"
+    )
+    private Long contentLength;
+
+    @Schema(
+        title = "The MIME type of the file"
+    )
+    private String contentType;
+
+    @Schema(
+        title = "The metadata of the file"
+    )
+    private Map<String, String> metadata;
+
+    @Schema(
+        title = "The version ID of the file"
+    )
+    private String versionId;
+}

--- a/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
@@ -34,4 +34,9 @@ public class FileInfo {
         title = "The version ID of the file"
     )
     private String versionId;
+
+    @Schema(
+            title = "An ETag is an opaque identifier assigned by a web server to a specific version of a resource found at a URL."
+    )
+    private String eTag;
 }

--- a/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
+++ b/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
@@ -83,15 +83,13 @@ class DownloadTest extends AbstractTest {
             .build();
 
         Download.Output outputFolder1 = downloadFolder1.run(runContext(downloadFolder1));
-        assertThat(outputFolder1.getUris().size(), is(3));
+        assertThat(outputFolder1.getFiles().size(), is(3));
 
-        assertThat(outputFolder1.getUris().keySet(), hasItems(
+        assertThat(outputFolder1.getFiles().keySet(), hasItems(
             containsString("a1.txt"),
             containsString("a2.txt"),
             containsString("b1.json")
         ));
-
-
 
         // Test 2: Download only from folder1 with delimiter (only direct files in folder1)
         Download downloadFolder1Direct = Download.builder()
@@ -107,10 +105,11 @@ class DownloadTest extends AbstractTest {
             .build();
 
         Download.Output outputFolder1Direct = downloadFolder1Direct.run(runContext(downloadFolder1Direct));
-        assertThat(outputFolder1Direct.getUris().size(), is(1));
-        assertThat(outputFolder1Direct.getUris().keySet(), hasItems(
+        assertThat(outputFolder1Direct.getFiles().size(), is(1));
+        assertThat(outputFolder1Direct.getFiles().keySet(), hasItems(
             containsString("b1.json")
         ));
+
         // Test 3: Use regexp to filter only .txt files from the entire hierarchy
         Download downloadTxtFiles = Download.builder()
             .id(DownloadTest.class.getSimpleName() + "-txtFiles")
@@ -125,9 +124,9 @@ class DownloadTest extends AbstractTest {
             .build();
 
         Download.Output outputTxtFiles = downloadTxtFiles.run(runContext(downloadTxtFiles));
-        assertThat(outputTxtFiles.getUris().size(), is(2));
+        assertThat(outputTxtFiles.getFiles().size(), is(2));
 
-        assertThat(outputTxtFiles.getUris().keySet(), hasItems(
+        assertThat(outputTxtFiles.getFiles().keySet(), hasItems(
             containsString("a1.txt"),
             containsString("a2.txt")
         ));

--- a/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
+++ b/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
@@ -1,0 +1,141 @@
+package io.kestra.plugin.aws.s3;
+
+import io.kestra.core.models.property.Property;
+import io.kestra.core.utils.IdUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class DownloadTest extends AbstractTest {
+
+    @Test
+    void runSingleFileMode() throws Exception {
+        this.createBucket();
+
+        // Upload a file to S3 to test download
+        String key = IdUtils.create() + "/test.yml";
+        URI sourceFile = storagePut("test.yml");
+
+        // Upload the file to S3
+        uploadFile(sourceFile, key);
+
+        // Test downloading a single file
+        Download download = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .bucket(Property.of(this.BUCKET))
+            .endpointOverride(Property.of(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.of(localstack.getAccessKey()))
+            .secretKeyId(Property.of(localstack.getSecretKey()))
+            .region(Property.of(localstack.getRegion()))
+            .key(Property.of(key))
+            .build();
+
+        Download.Output output = download.run(runContext(download));
+
+        // Assert single file download results
+        assertThat(output.getContentLength(), notNullValue());
+        assertThat(output.getContentType(), notNullValue());
+        assertThat(output.getUri().toString(), notNullValue());
+        assertThat(output.getMetadata().size(), notNullValue());
+    }
+
+    @Test
+    void runWithPrefixesAndFilters() throws Exception {
+        this.createBucket();
+
+        // Create a hierarchical structure with multiple folders
+        String basePrefix = IdUtils.create() + "/";
+        String folder1 = basePrefix + "folder1/";
+        String folder1Sub1 = folder1 + "subfolder1/";
+        String folder1Sub2 = folder1 + "subfolder2/";
+        String folder2 = basePrefix + "folder2/";
+
+        // Create test files in different locations in the hierarchy
+        URI fileA1 = storagePut("a1.txt");
+        URI fileA2 = storagePut("a2.txt");
+        URI fileB1 = storagePut("b1.json");
+        URI fileB2 = storagePut("b2.json");
+        URI fileC1 = storagePut("c1.yaml");
+
+        // Upload files to different locations in the S3 bucket hierarchy
+        uploadFile(fileA1, folder1Sub1 + "a1.txt");
+        uploadFile(fileA2, folder1Sub2 + "a2.txt");
+        uploadFile(fileB1, folder1 + "b1.json");
+        uploadFile(fileB2, folder2 + "b2.json");
+        uploadFile(fileC1, folder2 + "c1.yaml");
+
+        // Test 1: Download only from folder1 with all subfolders
+        Download downloadFolder1 = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-folder1")
+            .type(Download.class.getName())
+            .bucket(Property.of(this.BUCKET))
+            .endpointOverride(Property.of(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.of(localstack.getAccessKey()))
+            .secretKeyId(Property.of(localstack.getSecretKey()))
+            .region(Property.of(localstack.getRegion()))
+            .prefix(Property.of(folder1))
+            .build();
+
+        Download.Output outputFolder1 = downloadFolder1.run(runContext(downloadFolder1));
+        assertThat(outputFolder1.getUris().size(), is(3)); // a1.txt, a2.txt, b1.json
+
+        // Test 2: Download only from folder1 with delimiter (only direct files in folder1)
+        Download downloadFolder1Direct = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-folder1Direct")
+            .type(Download.class.getName())
+            .bucket(Property.of(this.BUCKET))
+            .endpointOverride(Property.of(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.of(localstack.getAccessKey()))
+            .secretKeyId(Property.of(localstack.getSecretKey()))
+            .region(Property.of(localstack.getRegion()))
+            .prefix(Property.of(folder1))
+            .delimiter(Property.of("/"))
+            .build();
+
+        Download.Output outputFolder1Direct = downloadFolder1Direct.run(runContext(downloadFolder1Direct));
+        assertThat(outputFolder1Direct.getUris().size(), is(1)); // only b1.json
+
+        // Test 3: Use regexp to filter only .txt files from the entire hierarchy
+        Download downloadTxtFiles = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-txtFiles")
+            .type(Download.class.getName())
+            .bucket(Property.of(this.BUCKET))
+            .endpointOverride(Property.of(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.of(localstack.getAccessKey()))
+            .secretKeyId(Property.of(localstack.getSecretKey()))
+            .region(Property.of(localstack.getRegion()))
+            .prefix(Property.of(basePrefix))
+            .regexp(Property.of(".*\\.txt$"))
+            .build();
+
+        Download.Output outputTxtFiles = downloadTxtFiles.run(runContext(downloadTxtFiles));
+        assertThat(outputTxtFiles.getUris().size(), is(2)); // a1.txt, a2.txt
+
+        // Verify the downloaded files have correct keys
+        assertThat(outputTxtFiles.getUris().keySet(), hasItems(
+            containsString("a1.txt"),
+            containsString("a2.txt")
+        ));
+    }
+
+    // Helper method to upload a single file to a specific location
+    private void uploadFile(URI source, String key) throws Exception {
+        Upload upload = Upload.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Upload.class.getName())
+            .bucket(Property.of(this.BUCKET))
+            .endpointOverride(Property.of(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.of(localstack.getAccessKey()))
+            .secretKeyId(Property.of(localstack.getSecretKey()))
+            .region(Property.of(localstack.getRegion()))
+            .from(source.toString())
+            .key(Property.of(key))
+            .build();
+        upload.run(runContext(upload));
+    }
+}


### PR DESCRIPTION
## What changes are being made and why?
#296 

This PR redesigns the AWS S3 Download task to add the ability to download multiple files, while maintaining the same functionality when downloading a single file.

## How the changes have been QAed?
- add tesst in `DownoaldTest`
- tested locally
<img width="764" alt="Screenshot 2025-05-06 at 15 29 57" src="https://github.com/user-attachments/assets/bf5629d3-0d13-400c-9d6e-e06058cb2d30" />

```json

"outputs": {
        "files": {
          "path/to/file/myfile_7652765205912941721.upl": {
            "uri": "kestra:///company/team/aws-s3-download-multiple-file/executions/5K6hhhA1WRyDRwA3Mq4eKa/tasks/download/3mlTWHEMsUZOz36RxlPESf/9593450800659192942.upl",
            "metadata": {},
            "contentType": "application/octet-stream",
            "contentLength": 110368
          },
          "path/to/file/myfile2_14451032647395773406.upl": {
            "uri": "kestra:///company/team/aws-s3-download-multiple-file/executions/5K6hhhA1WRyDRwA3Mq4eKa/tasks/download/3mlTWHEMsUZOz36RxlPESf/5436637045368725465.upl",
            "metadata": {},
            "contentType": "application/octet-stream",
            "contentLength": 126399
          }
        }
      }

```


## Additional notes
- Documentation has been updated to clearly explain the two operation modes
- No breaking changes have been introduced to existing flows

## Question
- do we continue to return metadata if they are null?