### PR TITLE
feat(plugin-aws): Added the new ubiquitous from in Publish.java closes #12354

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/sns/Publish.java
+++ b/src/main/java/io/kestra/plugin/aws/sns/Publish.java
@@ -5,20 +5,17 @@ import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.aws.sns.model.Message;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 
-import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -35,8 +32,8 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         @Example(
             full = true,
             title = """
-            Send an SMS message using AWS SNS
-            """,
+                Send an SMS message using AWS SNS
+                """,
             code = """
                 id: aws_sns_publish
                 namespace: company.team
@@ -57,17 +54,17 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         @Example(
             full = true,
             title = """
-            Send an SMS message using AWS SNS based on a runtime-specific input
-            """,
+                Send an SMS message using AWS SNS based on a runtime-specific input
+                """,
             code = """
                 id: send_sms
                 namespace: company.team
-                
+
                 inputs:
                   - id: sms_text
                     type: STRING
                     defaults: Hello from Kestra and AWS SNS!
-                
+
                 tasks:
                   - id: send_sms
                     type: io.kestra.plugin.aws.sns.Publish
@@ -90,7 +87,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         )
     }
 )
-public class Publish extends AbstractSns implements RunnableTask<Publish.Output>, io.kestra.core.models.property.Data.From {
+public class Publish extends AbstractSns implements RunnableTask<Publish.Output>, Data.From {
     @NotNull
     @Schema(
         title = Data.From.TITLE,
@@ -110,9 +107,9 @@ public class Publish extends AbstractSns implements RunnableTask<Publish.Output>
                     snsClient.publish(publishRequest);
                     return 1;
                 }))
-               .reduce(Integer::sum)
-               .blockOptional()
-               .orElse(0);
+                .reduce(Integer::sum)
+                .blockOptional()
+                .orElse(0);
 
             // metrics
             runContext.metric(Counter.of("sns.publish.messages", count, "topic", topicArn));

--- a/src/main/java/io/kestra/plugin/aws/sqs/Publish.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/Publish.java
@@ -5,20 +5,17 @@ import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.aws.sqs.model.Message;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
-import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
-import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -58,12 +55,12 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
             code = """
                 id: sqs_publish_message
                 namespace: company.team
-                
+
                 inputs:
                   - id: message
                     type: STRING
                     defaults: Hi from Kestra!
-                
+
                 tasks:
                   - id: publish_message
                     type: io.kestra.plugin.aws.sqs.Publish
@@ -85,7 +82,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
         )
     }
 )
-public class Publish extends AbstractSqs implements RunnableTask<Publish.Output>,io.kestra.core.models.property.Data.From {
+public class Publish extends AbstractSqs implements RunnableTask<Publish.Output>, Data.From {
     @NotNull
     @Schema(
         title = Data.From.TITLE,
@@ -93,7 +90,7 @@ public class Publish extends AbstractSqs implements RunnableTask<Publish.Output>
         anyOf = {String.class, List.class, Message.class}
     )
     private Object from;
-    
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         var queueUrl = runContext.render(getQueueUrl()).as(String.class).orElseThrow();
@@ -108,7 +105,7 @@ public class Publish extends AbstractSqs implements RunnableTask<Publish.Output>
                 .reduce(Integer::sum)
                 .blockOptional()
                 .orElse(0);
-            
+
             // metrics
             runContext.metric(Counter.of("sqs.publish.messages", count, "queue", queueUrl));
 


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra/issues/12354

Summary

This PR refactors the plugin-aws to use the new Data.From interface for unified message input handling.

Affected Files

Publish.java → replaced manual parsing logic for from with Data.from(from).read(runContext).

Changes

Implemented the Data.From interface in Publish.

Simplified input reading by removing manual checks for String, List, and URI types.

Now reads all message sources (map, list, or file) through the common Data.from abstraction.

Notes

No changes to message publishing behavior — only cleaner, standardized data input handling.