### PR TITLE
docs: add H1 heading to plugin doc markdown

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.aws.md
+++ b/src/main/resources/doc/io.kestra.plugin.aws.md
@@ -1,3 +1,5 @@
+# How to Use the AWS Plugin
+
 ### Authentication
 
 All tasks must be authenticated for the AWS Platform.


### PR DESCRIPTION
## Summary

- Adds `# How to Use the AWS Plugin` as an H1 at the top of `src/main/resources/doc/io.kestra.plugin.aws.md`
- Now that `ui-libs` no longer injects a hardcoded H2, the plugin's markdown file owns the section heading entirely

## Test plan

- [ ] Visit `/plugins/plugin-aws` — the description section should open with "How to Use the AWS Plugin" as an H1
- [ ] Right-sidebar TOC entry label matches the heading text
- [ ] Existing content (Authentication, credentials chain, etc.) is unchanged

Part-of: https://github.com/kestra-io/docs/issues/4688