### PR TITLE
feat: add checksum for downloads

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/s3/Download.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Download.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -45,6 +46,24 @@ import io.kestra.core.models.annotations.PluginProperty;
                     region: "eu-central-1"
                     bucket: "my-bucket"
                     key: "path/to/file"
+                """
+        ),
+        @Example(
+            full = true,
+            title = "Download a file and verify the stored S3 checksum during transfer.",
+            code = """
+                id: aws_s3_download_validate_checksum
+                namespace: company.team
+
+                tasks:
+                  - id: download
+                    type: io.kestra.plugin.aws.s3.Download
+                    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+                    secretKeyId: "{{ secret('AWS_SECRET_KEY_ID') }}"
+                    region: "eu-central-1"
+                    bucket: "my-bucket"
+                    key: "path/to/file"
+                    validateChecksum: true
                 """
         )
     },
@@ -135,6 +154,16 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
     @PluginProperty(group = "connection")
     private Property<String> expectedBucketOwner;
 
+    @Schema(
+        title = "Validate checksum after download",
+        description = "When true, requests S3 to return the stored checksum and the AWS SDK verifies the downloaded bytes during transfer. " +
+            "The object must have been uploaded with a checksum algorithm (SHA1, SHA256, CRC32, or CRC32C) for verification to occur; " +
+            "if the object has no stored checksum, a warning is logged and the download is not verified."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> validateChecksum = Property.ofValue(false);
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         String bucket = runContext.render(this.bucket).as(String.class).orElseThrow();
@@ -166,6 +195,8 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
             GetObjectRequest request = buildGetObjectRequest(runContext, bucket, key);
             Pair<GetObjectResponse, URI> download = S3Service.download(runContext, client, request);
 
+            Pair<String, String> checksum = S3Service.extractChecksum(download.getLeft());
+
             return Output.builder()
                 .uri(download.getRight())
                 .eTag(download.getLeft().eTag())
@@ -173,6 +204,8 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
                 .contentType(download.getLeft().contentType())
                 .metadata(download.getLeft().metadata())
                 .versionId(download.getLeft().versionId())
+                .checksumAlgorithm(checksum.getLeft())
+                .checksumValue(checksum.getRight())
                 .build();
         }
     }
@@ -194,6 +227,10 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
             builder.expectedBucketOwner(runContext.render(this.expectedBucketOwner).as(String.class).orElseThrow());
         }
 
+        if (runContext.render(this.validateChecksum).as(Boolean.class).orElse(false)) {
+            builder.checksumMode(ChecksumMode.ENABLED);
+        }
+
         return builder.build();
     }
 
@@ -212,6 +249,7 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
                 Pair<GetObjectResponse, URI> download = S3Service.download(runContext, client, request);
 
                 String key = object.getKey();
+                Pair<String, String> checksum = S3Service.extractChecksum(download.getLeft());
                 files.put(
                     key, FileInfo.builder()
                         .uri(download.getRight())
@@ -220,6 +258,8 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
                         .metadata(download.getLeft().metadata())
                         .eTag(download.getLeft().eTag())
                         .versionId(download.getLeft().versionId())
+                        .checksumAlgorithm(checksum.getLeft())
+                        .checksumValue(checksum.getRight())
                         .build()
                 );
             }
@@ -285,5 +325,16 @@ public class Download extends AbstractS3Object implements RunnableTask<Download.
         )
         private final Map<String, FileInfo> files;
 
+        @Schema(
+            title = "Checksum algorithm reported by S3",
+            description = "One of SHA1, SHA256, CRC32, CRC32C. Null when validateChecksum was not enabled or the object has no stored checksum."
+        )
+        private final String checksumAlgorithm;
+
+        @Schema(
+            title = "Checksum value reported by S3 (base64-encoded)",
+            description = "Populated when validateChecksum is true and the object has a stored checksum."
+        )
+        private final String checksumValue;
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Downloads.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
@@ -49,6 +50,24 @@ import io.kestra.core.models.annotations.PluginProperty;
                     region: "eu-central-1"
                     bucket: "my-bucket"
                     prefix: "sub-dir"
+                """
+        ),
+        @Example(
+            full = true,
+            title = "Download a prefix and verify the stored S3 checksum on each object.",
+            code = """
+                id: aws_s3_downloads_validate_checksum
+                namespace: company.team
+
+                tasks:
+                  - id: downloads
+                    type: io.kestra.plugin.aws.s3.Downloads
+                    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+                    secretKeyId: "{{ secret('AWS_SECRET_KEY_ID') }}"
+                    region: "eu-central-1"
+                    bucket: "my-bucket"
+                    prefix: "sub-dir"
+                    validateChecksum: true
                 """
         )
     },
@@ -118,6 +137,16 @@ public class Downloads extends AbstractS3Object implements RunnableTask<Download
 
     private Copy.CopyObject moveTo;
 
+    @Schema(
+        title = "Validate checksum after download",
+        description = "When true, requests S3 to return the stored checksum and the AWS SDK verifies the downloaded bytes during transfer. " +
+            "Each object must have been uploaded with a checksum algorithm (SHA1, SHA256, CRC32, or CRC32C) for verification to occur; " +
+            "if an object has no stored checksum, a warning is logged and the download is not verified."
+    )
+    @Builder.Default
+    @PluginProperty(group = "reliability")
+    private Property<Boolean> validateChecksum = Property.ofValue(false);
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         List task = List.builder()
@@ -147,6 +176,8 @@ public class Downloads extends AbstractS3Object implements RunnableTask<Download
             .build();
         List.Output run = task.run(runContext);
 
+        boolean validate = runContext.render(this.validateChecksum).as(Boolean.class).orElse(false);
+
         try (S3AsyncClient client = this.asyncClient(runContext)) {
             java.util.List<S3Object> list = run
                 .getObjects()
@@ -157,9 +188,17 @@ public class Downloads extends AbstractS3Object implements RunnableTask<Download
                         .bucket(runContext.render(bucket).as(String.class).orElseThrow())
                         .key(object.getKey());
 
-                    Pair<GetObjectResponse, URI> download = S3Service.download(runContext, client, builder.build());
+                    if (validate) {
+                        builder.checksumMode(ChecksumMode.ENABLED);
+                    }
 
-                    return object.withUri(download.getRight());
+                    Pair<GetObjectResponse, URI> download = S3Service.download(runContext, client, builder.build());
+                    Pair<String, String> checksum = S3Service.extractChecksum(download.getLeft());
+
+                    return object
+                        .withUri(download.getRight())
+                        .withChecksumAlgorithm(checksum.getLeft())
+                        .withChecksumValue(checksum.getRight());
                 }))
                 .filter(object -> !object.getKey().endsWith("/")) // filter directory
                 .collect(Collectors.toList());
@@ -177,7 +216,7 @@ public class Downloads extends AbstractS3Object implements RunnableTask<Download
 
             Map<String, URI> outputFiles = list.stream()
                 .map(obj -> new AbstractMap.SimpleEntry<>(obj.getKey(), obj.getUri()))
-                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
 
             S3Service.performAction(
                 run.getObjects(),

--- a/src/main/java/io/kestra/plugin/aws/s3/S3Service.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/S3Service.java
@@ -22,6 +22,7 @@ import io.kestra.plugin.aws.s3.models.S3Object;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
@@ -57,8 +58,35 @@ public class S3Service {
 
             runContext.metric(Counter.of("file.size", response.contentLength()));
 
+            if (request.checksumMode() == ChecksumMode.ENABLED && extractChecksum(response).getLeft() == null) {
+                runContext.logger().warn(
+                    "Checksum validation requested for key '{}' but the object has no stored checksum; transfer was not verified.",
+                    request.key()
+                );
+            }
+
             return Pair.of(response, runContext.storage().putFile(tempFile));
         }
+    }
+
+    /**
+     * Returns the first non-null checksum from a {@link GetObjectResponse} as an (algorithm, base64-value) pair.
+     * Both elements are null when the response carries no checksum.
+     */
+    public static Pair<String, String> extractChecksum(GetObjectResponse response) {
+        if (response.checksumSHA256() != null) {
+            return Pair.of("SHA256", response.checksumSHA256());
+        }
+        if (response.checksumSHA1() != null) {
+            return Pair.of("SHA1", response.checksumSHA1());
+        }
+        if (response.checksumCRC32() != null) {
+            return Pair.of("CRC32", response.checksumCRC32());
+        }
+        if (response.checksumCRC32C() != null) {
+            return Pair.of("CRC32C", response.checksumCRC32C());
+        }
+        return Pair.of(null, null);
     }
 
     static void performAction(

--- a/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/models/FileInfo.java
@@ -46,4 +46,18 @@ public class FileInfo {
     )
     @PluginProperty(group = "advanced")
     private String eTag;
+
+    @Schema(
+        title = "Checksum algorithm reported by S3",
+        description = "One of SHA1, SHA256, CRC32, CRC32C. Null when validateChecksum was not enabled or the object has no stored checksum."
+    )
+    @PluginProperty(group = "advanced")
+    private String checksumAlgorithm;
+
+    @Schema(
+        title = "Checksum value reported by S3 (base64-encoded)",
+        description = "Populated when validateChecksum is true and the object has a stored checksum."
+    )
+    @PluginProperty(group = "advanced")
+    private String checksumValue;
 }

--- a/src/main/java/io/kestra/plugin/aws/s3/models/S3Object.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/models/S3Object.java
@@ -17,6 +17,10 @@ public class S3Object {
     Long size;
     Instant lastModified;
     Owner owner;
+    @With
+    String checksumAlgorithm;
+    @With
+    String checksumValue;
 
     public static S3Object of(software.amazon.awssdk.services.s3.model.S3Object object) {
         return S3Object.builder()

--- a/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
+++ b/src/test/java/io/kestra/plugin/aws/s3/DownloadTest.java
@@ -1,12 +1,17 @@
 package io.kestra.plugin.aws.s3;
 
+import java.io.InputStream;
 import java.net.URI;
+import java.security.MessageDigest;
+import java.util.Base64;
 
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
 import io.kestra.core.models.property.Property;
+import io.kestra.core.tenant.TenantService;
 import io.kestra.core.utils.IdUtils;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -152,6 +157,127 @@ class DownloadTest extends AbstractTest {
             .key(Property.ofValue(key))
             .build();
         upload.run(runContext(upload));
+    }
+
+    private void uploadFileWithSha256(URI source, String key, String sha256Base64) throws Exception {
+        Upload upload = Upload.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Upload.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .from(source.toString())
+            .key(Property.ofValue(key))
+            .checksumAlgorithm(Property.ofValue(ChecksumAlgorithm.SHA256))
+            .checksum(Property.ofValue(sha256Base64))
+            .build();
+        upload.run(runContext(upload));
+    }
+
+    private String sha256Base64(URI storageUri) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream in = storageInterface.get(TenantService.MAIN_TENANT, null, storageUri)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                digest.update(buf, 0, n);
+            }
+        }
+        return Base64.getEncoder().encodeToString(digest.digest());
+    }
+
+    @Test
+    void runWithValidateChecksumSuccess() throws Exception {
+        this.createBucket();
+
+        String key = IdUtils.create() + "/test.yml";
+        URI sourceFile = storagePut("test.yml");
+        String expectedSha256 = sha256Base64(sourceFile);
+
+        uploadFileWithSha256(sourceFile, key, expectedSha256);
+
+        Download download = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-validateChecksum")
+            .type(Download.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .key(Property.ofValue(key))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        Download.Output output = download.run(runContext(download));
+
+        assertThat(output.getUri(), notNullValue());
+        assertThat(output.getChecksumAlgorithm(), is("SHA256"));
+        assertThat(output.getChecksumValue(), is(expectedSha256));
+    }
+
+    @Test
+    void runWithValidateChecksumNoStoredChecksum() throws Exception {
+        this.createBucket();
+
+        String key = IdUtils.create() + "/test.yml";
+        URI sourceFile = storagePut("test.yml");
+
+        uploadFile(sourceFile, key);
+
+        Download download = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-validateChecksumMissing")
+            .type(Download.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .key(Property.ofValue(key))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        Download.Output output = download.run(runContext(download));
+
+        assertThat(output.getUri(), notNullValue());
+        assertThat(output.getChecksumAlgorithm(), nullValue());
+        assertThat(output.getChecksumValue(), nullValue());
+    }
+
+    @Test
+    void runWithValidateChecksumMultiFile() throws Exception {
+        this.createBucket();
+
+        String basePrefix = IdUtils.create() + "/multi-checksum/";
+
+        URI fileA = storagePut("a.txt");
+        URI fileB = storagePut("b.txt");
+        String shaA = sha256Base64(fileA);
+        String shaB = sha256Base64(fileB);
+
+        uploadFileWithSha256(fileA, basePrefix + "a.txt", shaA);
+        uploadFileWithSha256(fileB, basePrefix + "b.txt", shaB);
+
+        Download download = Download.builder()
+            .id(DownloadTest.class.getSimpleName() + "-validateChecksumMulti")
+            .type(Download.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .prefix(Property.ofValue(basePrefix))
+            .validateChecksum(Property.ofValue(true))
+            .build();
+
+        Download.Output output = download.run(runContext(download));
+
+        assertThat(output.getFiles().size(), is(2));
+        output.getFiles().values().forEach(fileInfo -> {
+            assertThat(fileInfo.getChecksumAlgorithm(), is("SHA256"));
+            assertThat(fileInfo.getChecksumValue(), notNullValue());
+        });
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/aws/s3/DownloadsTest.java
+++ b/src/test/java/io/kestra/plugin/aws/s3/DownloadsTest.java
@@ -1,15 +1,24 @@
 package io.kestra.plugin.aws.s3;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.security.MessageDigest;
+import java.util.Base64;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
 import io.kestra.core.models.property.Property;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.aws.s3.models.S3Object;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 class DownloadsTest extends AbstractTest {
     @Test
@@ -33,7 +42,7 @@ class DownloadsTest extends AbstractTest {
         Downloads.Output run = task.run(runContext(task));
 
         assertThat(run.getObjects().size(), is(2));
-        assertThat(run.getObjects().get(0).getUri().toString(), endsWith(".yml"));
+        assertThat(run.getObjects().getFirst().getUri().toString(), endsWith(".yml"));
         assertThat(run.getOutputFiles().size(), is(2));
 
         List list = list().build();
@@ -104,6 +113,73 @@ class DownloadsTest extends AbstractTest {
         Downloads.Output run = task.run(runContext(task));
 
         assertThat(run.getObjects().size(), is(3));
+    }
+
+    @Test
+    void validateChecksum() throws Exception {
+        this.createBucket();
+
+        String basePrefix = "/tasks/s3-checksum-" + IdUtils.create();
+
+        URI source1 = storagePut(null);
+        URI source2 = storagePut(null);
+        String sha1 = sha256Base64(source1);
+        String sha2 = sha256Base64(source2);
+        String key1 = basePrefix + "/" + IdUtils.create() + ".yml";
+        String key2 = basePrefix + "/" + IdUtils.create() + ".yml";
+
+        uploadWithSha256(source1, key1, sha1);
+        uploadWithSha256(source2, key2, sha2);
+
+        Downloads task = Downloads.builder()
+            .id(DownloadsTest.class.getSimpleName())
+            .type(Downloads.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .prefix(Property.ofValue(basePrefix))
+            .validateChecksum(Property.ofValue(true))
+            .action(Property.ofValue(ActionInterface.Action.NONE))
+            .build();
+
+        Downloads.Output run = task.run(runContext(task));
+
+        assertThat(run.getObjects().size(), is(2));
+        for (S3Object object : run.getObjects()) {
+            assertThat(object.getChecksumAlgorithm(), is("SHA256"));
+            assertThat(object.getChecksumValue(), notNullValue());
+        }
+    }
+
+    private void uploadWithSha256(URI source, String key, String sha256Base64) throws Exception {
+        Upload upload = Upload.builder()
+            .id(DownloadsTest.class.getSimpleName())
+            .type(Upload.class.getName())
+            .bucket(Property.ofValue(this.BUCKET))
+            .endpointOverride(Property.ofValue(localstack.getEndpointOverride(LocalStackContainer.Service.S3).toString()))
+            .accessKeyId(Property.ofValue(localstack.getAccessKey()))
+            .secretKeyId(Property.ofValue(localstack.getSecretKey()))
+            .region(Property.ofValue(localstack.getRegion()))
+            .from(source.toString())
+            .key(Property.ofValue(key))
+            .checksumAlgorithm(Property.ofValue(ChecksumAlgorithm.SHA256))
+            .checksum(Property.ofValue(sha256Base64))
+            .build();
+        upload.run(runContext(upload));
+    }
+
+    private String sha256Base64(URI storageUri) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream in = storageInterface.get(TenantService.MAIN_TENANT, null, storageUri)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                digest.update(buf, 0, n);
+            }
+        }
+        return Base64.getEncoder().encodeToString(digest.digest());
     }
 
     @Test


### PR DESCRIPTION
link to issue https://github.com/kestra-io/kestra-ee/issues/5699

### QA

Download a file, upload it with checksum then dowload it

``` yaml
id: aws_s3_dl
namespace: company.team
inputs:
  - id: access
    defaults: "aa"
    type: STRING

  - id: secret
    type: STRING
    defaults: "aa"

tasks:

 - id: download_file
   type: io.kestra.plugin.core.http.Download
   uri: "https://raw.githubusercontent.com/cedille/ial/refs/heads/master/hello-world.txt"

 - id: upload
   type: io.kestra.plugin.aws.s3.Upload
   region: "eu-west-1"
   accessKeyId: "{{ inputs.access }}"
   secretKeyId: "{{ inputs.secret }}"
   from: "{{ outputs.download_file.uri }}"
   bucket: "qa-test-kestra"
   key: "jma-hello.txt"
   checksumAlgorithm: "SHA256"
   


 - id: download
   type: io.kestra.plugin.aws.s3.Download
   accessKeyId: "{{ inputs.access }}"
   secretKeyId: "{{ inputs.secret }}"
   region: "eu-west-1"
   bucket: "qa-test-kestra"
   key: "jma-hello.txt"
   validateChecksum: true
    ```

<img width="955" height="600" alt="image" src="https://github.com/user-attachments/assets/7556af03-e72f-40e2-96ea-09a68f358f33" />


