### PR TITLE
fix(plugin-aws): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/auth/package-info.java
+++ b/src/main/java/io/kestra/plugin/aws/auth/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Authentication",
+    title = "AWS Authentication",
     description = "Tasks that generate authentication material for AWS services, such as short-lived tokens to access Amazon EKS clusters.",
     categories = { PluginSubGroup.PluginCategory.CLOUD }
 )

--- a/src/main/java/io/kestra/plugin/aws/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/aws/cli/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "CLI",
+    title = "AWS CLI",
     description = "Tasks that run AWS CLI commands (inside a container by default), reuse Kestra credentials and environment variables, and capture stdout or files produced by the CLI.",
     categories = { PluginSubGroup.PluginCategory.CLOUD, PluginSubGroup.PluginCategory.DATA, PluginSubGroup.PluginCategory.INFRASTRUCTURE }
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge