### PR TITLE
fix(sqs): keep RealtimeTrigger polling on transient errors

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.aws.sqs;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -26,6 +27,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -105,10 +107,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private static final Duration POLL_ERROR_BACKOFF_BASE = Duration.ofSeconds(1);
     private static final Duration POLL_ERROR_BACKOFF_MAX = Duration.ofSeconds(30);
-    // Slice size for interruptible sleep so stop() is responsive within this window.
     private static final Duration POLL_SLEEP_SLICE = Duration.ofMillis(200);
 
-    // SQS error codes that indicate a permanent configuration problem, not a transient one.
     private static final Set<String> FATAL_ERROR_CODES = Set.of(
         "AWS.SimpleQueueService.NonExistentQueue",
         "QueueDoesNotExist",
@@ -229,10 +229,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             fluxSink ->
             {
                 Logger logger = runContext.logger();
-                // Tracks whether fluxSink.error() was already called so we skip complete() afterward.
                 var signalledError = false;
                 try (SqsAsyncClient sqsClient = task.asyncClient(runContext, runContext.render(clientRetryMaxAttempts).as(Integer.class).orElseThrow())) {
-                    // Render once before the loop to avoid redundant rendering on every iteration.
                     var rWaitTimeSeconds = (int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds();
                     var rMaxNumberOfMessages = runContext.render(maxNumberOfMessage).as(Integer.class).orElseThrow();
                     var rVisibilityTimeout = runContext.render(visibilityTimeout).as(Integer.class).orElse(30);
@@ -244,61 +242,28 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                     var currentBackoff = POLL_ERROR_BACKOFF_BASE;
 
                     while (isActive.get()) {
-                        ReceiveMessageRequest receiveRequest = ReceiveMessageRequest.builder()
+                        var receiveRequest = ReceiveMessageRequest.builder()
                             .queueUrl(renderedQueueUrl)
                             .waitTimeSeconds(rWaitTimeSeconds)
                             .maxNumberOfMessages(rMaxNumberOfMessages)
                             .visibilityTimeout(rVisibilityTimeout)
                             .build();
 
-                        final CompletableFuture<ReceiveMessageResponse> future = sqsClient.receiveMessage(receiveRequest);
+                        var future = sqsClient.receiveMessage(receiveRequest);
 
                         try {
                             ReceiveMessageResponse response = future.get();
 
-                            // Reset backoff after a successful poll cycle.
                             currentBackoff = POLL_ERROR_BACKOFF_BASE;
 
                             if (!response.messages().isEmpty()) {
                                 logger.debug("Received {} message(s) from queue '{}'.", response.messages().size(), renderedQueueUrl);
                             }
 
-                            for (var message : response.messages()) {
-                                // Deserialize: a bad message body must not kill the whole loop.
-                                Object body;
-                                try {
-                                    body = rSerdeType.deserialize(message.body());
-                                } catch (java.io.IOException e) {
-                                    logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
-                                    continue;
-                                }
-
-                                fluxSink.next(Message.builder().data(body).build());
-
-                                if (rAutoDelete) {
-                                    try {
-                                        sqsClient.deleteMessage(
-                                            DeleteMessageRequest.builder()
-                                                .queueUrl(renderedQueueUrl)
-                                                .receiptHandle(message.receiptHandle())
-                                                .build()
-                                        ).get();
-                                    } catch (InterruptedException ie) {
-                                        // Restore interrupt flag and shut down cleanly.
-                                        Thread.currentThread().interrupt();
-                                        isActive.set(false);
-                                        break;
-                                    } catch (ExecutionException de) {
-                                        // Accept at-least-once redelivery rather than mixing delete
-                                        // failures into the receive-error/backoff path.
-                                        var cause = de.getCause() != null ? de.getCause() : de;
-                                        logger.warn("Failed to delete SQS message (will be redelivered): {}", cause.getMessage());
-                                    }
-                                }
-                            }
+                            emitAndDelete(fluxSink, sqsClient, renderedQueueUrl, response.messages(), rAutoDelete, rSerdeType, logger);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
-                            isActive.set(false); // proactively stop polling
+                            isActive.set(false);
                         } catch (ExecutionException e) {
                             var cause = e.getCause() != null ? e.getCause() : e;
                             if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {
@@ -307,8 +272,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                                 isActive.set(false);
                                 fluxSink.error(cause);
                             } else {
-                                // Transient error (connection-pool timeout, throttling, network blip).
-                                // Apply capped exponential backoff to avoid a busy-loop under hard-down endpoints.
                                 logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
                                 sleepInterruptibly(currentBackoff);
                                 currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
@@ -326,6 +289,49 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 }
             }
         );
+    }
+
+    private void emitAndDelete(
+        FluxSink<Message> sink,
+        SqsAsyncClient client,
+        String queueUrl,
+        List<software.amazon.awssdk.services.sqs.model.Message> messages,
+        boolean autoDelete,
+        SerdeType serdeType,
+        Logger logger
+    ) {
+        for (var message : messages) {
+            Object body;
+            try {
+                body = serdeType.deserialize(message.body());
+            } catch (java.io.IOException e) {
+                logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
+                continue;
+            }
+
+            sink.next(Message.builder().data(body).build());
+
+            if (autoDelete) {
+                try {
+                    client.deleteMessage(
+                        DeleteMessageRequest.builder()
+                            .queueUrl(queueUrl)
+                            .receiptHandle(message.receiptHandle())
+                            .build()
+                    ).get();
+                } catch (InterruptedException ie) {
+                    // Restore interrupt flag and shut down cleanly.
+                    Thread.currentThread().interrupt();
+                    isActive.set(false);
+                    break;
+                } catch (ExecutionException de) {
+                    // Accept at-least-once redelivery rather than mixing delete
+                    // failures into the receive-error/backoff path.
+                    var cause = de.getCause() != null ? de.getCause() : de;
+                    logger.warn("Failed to delete SQS message (will be redelivered): {}", cause.getMessage());
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -251,7 +251,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                         isActive.set(false); // proactively stop polling
                     } catch (ExecutionException e) {
                         var cause = e.getCause() != null ? e.getCause() : e;
-                        if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {
+                        if (cause instanceof SqsException sqsEx && isNonRetryable(sqsEx)) {
                             logger.error("Fatal SQS error on queue '{}': {}. Stopping trigger.", renderedQueueUrl, cause.getMessage());
                             signalledError = true;
                             isActive.set(false);
@@ -349,7 +349,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         }
     }
 
-    // Sliced so stop() (isActive=false) cuts the wait within one slice, not the full backoff.
+    // sliced so stop() can cut the wait short instead of blocking the whole backoff
     private void sleepInterruptibly(Duration delay) {
         var remaining = delay.toMillis();
         while (isActive.get() && remaining > 0) {
@@ -365,8 +365,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         }
     }
 
-    private static boolean isFatal(SqsException ex) {
-        // client-side errors (4xx) other than throttling are config/permission problems that retrying will not fix
+    // a non-throttling 4xx is a permanent config or permission error, retrying will not help
+    private static boolean isNonRetryable(SqsException ex) {
         return ex.statusCode() >= 400 && ex.statusCode() < 500 && !ex.isThrottlingException();
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.aws.sqs;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -28,7 +29,8 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -287,6 +289,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         SerdeType serdeType,
         Logger logger
     ) {
+        var handles = autoDelete ? new ArrayList<String>(messages.size()) : null;
+
         for (var message : messages) {
             Object body;
             try {
@@ -300,24 +304,46 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             sink.next(Message.builder().data(body).build());
 
             if (autoDelete) {
-                try {
-                    client.deleteMessage(
-                        DeleteMessageRequest.builder()
-                            .queueUrl(queueUrl)
-                            .receiptHandle(message.receiptHandle())
-                            .build()
-                    ).get();
-                } catch (InterruptedException ie) {
-                    // Restore interrupt flag and shut down cleanly.
-                    Thread.currentThread().interrupt();
-                    isActive.set(false);
-                    break;
-                } catch (ExecutionException de) {
-                    // Accept at-least-once redelivery instead of routing delete failures to backoff.
-                    var cause = de.getCause() != null ? de.getCause() : de;
-                    logger.warn("Failed to delete SQS message (will be redelivered): {}", cause.getMessage());
-                }
+                handles.add(message.receiptHandle());
             }
+        }
+
+        if (handles == null || handles.isEmpty()) {
+            return;
+        }
+
+        // One batch covers the whole poll: SQS caps both maxNumberOfMessages and deleteMessageBatch at 10.
+        var entries = new ArrayList<DeleteMessageBatchRequestEntry>(handles.size());
+        for (int i = 0; i < handles.size(); i++) {
+            entries.add(DeleteMessageBatchRequestEntry.builder()
+                .id(String.valueOf(i))
+                .receiptHandle(handles.get(i))
+                .build());
+        }
+
+        try {
+            var response = client.deleteMessageBatch(
+                DeleteMessageBatchRequest.builder()
+                    .queueUrl(queueUrl)
+                    .entries(entries)
+                    .build()
+            ).get();
+
+            if (!response.failed().isEmpty()) {
+                // Partial failures cause at-least-once redelivery; log and continue.
+                var failedIds = response.failed().stream()
+                    .map(f -> "id=" + f.id() + " code=" + f.code() + " msg=" + f.message())
+                    .toList();
+                logger.warn("SQS batch delete had {} partial failure(s) (will be redelivered): {}", response.failed().size(), failedIds);
+            }
+        } catch (InterruptedException ie) {
+            // Restore interrupt flag and shut down cleanly.
+            Thread.currentThread().interrupt();
+            isActive.set(false);
+        } catch (ExecutionException de) {
+            // Accept at-least-once redelivery instead of routing delete failures to backoff.
+            var cause = de.getCause() != null ? de.getCause() : de;
+            logger.warn("Failed to delete SQS message batch (will be redelivered): {}", cause.getMessage());
         }
     }
 

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -1,9 +1,9 @@
 package io.kestra.plugin.aws.sqs;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,7 +31,6 @@ import reactor.core.publisher.FluxSink;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 import io.kestra.core.models.annotations.PluginProperty;
 
@@ -225,70 +224,65 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         final RunContext runContext) throws Exception {
         var renderedQueueUrl = runContext.render(getQueueUrl()).as(String.class).orElseThrow();
 
-        return Flux.create(
-            fluxSink ->
-            {
-                Logger logger = runContext.logger();
-                var signalledError = false;
-                try (SqsAsyncClient sqsClient = task.asyncClient(runContext, runContext.render(clientRetryMaxAttempts).as(Integer.class).orElseThrow())) {
-                    var rWaitTimeSeconds = (int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds();
-                    var rMaxNumberOfMessages = runContext.render(maxNumberOfMessage).as(Integer.class).orElseThrow();
-                    var rVisibilityTimeout = runContext.render(visibilityTimeout).as(Integer.class).orElse(30);
-                    var rAutoDelete = runContext.render(autoDelete).as(Boolean.class).orElse(true);
-                    var rSerdeType = runContext.render(serdeType).as(SerdeType.class).orElse(SerdeType.STRING);
+        return Flux.create(fluxSink -> {
+            var logger = runContext.logger();
+            var signalledError = false;
+            try (var sqsClient = task.asyncClient(runContext, runContext.render(clientRetryMaxAttempts).as(Integer.class).orElseThrow())) {
+                var rWaitTimeSeconds = (int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds();
+                var rMaxNumberOfMessages = runContext.render(maxNumberOfMessage).as(Integer.class).orElseThrow();
+                var rVisibilityTimeout = runContext.render(visibilityTimeout).as(Integer.class).orElse(30);
+                var rAutoDelete = runContext.render(autoDelete).as(Boolean.class).orElse(true);
+                var rSerdeType = runContext.render(serdeType).as(SerdeType.class).orElse(SerdeType.STRING);
 
-                    logger.info("Starting SQS consumption from queue '{}'.", renderedQueueUrl);
+                logger.info("Starting SQS consumption from queue '{}'.", renderedQueueUrl);
 
-                    var currentBackoff = POLL_ERROR_BACKOFF_BASE;
+                var currentBackoff = POLL_ERROR_BACKOFF_BASE;
 
-                    while (isActive.get()) {
-                        var receiveRequest = ReceiveMessageRequest.builder()
-                            .queueUrl(renderedQueueUrl)
-                            .waitTimeSeconds(rWaitTimeSeconds)
-                            .maxNumberOfMessages(rMaxNumberOfMessages)
-                            .visibilityTimeout(rVisibilityTimeout)
-                            .build();
+                while (isActive.get()) {
+                    var receiveRequest = ReceiveMessageRequest.builder()
+                        .queueUrl(renderedQueueUrl)
+                        .waitTimeSeconds(rWaitTimeSeconds)
+                        .maxNumberOfMessages(rMaxNumberOfMessages)
+                        .visibilityTimeout(rVisibilityTimeout)
+                        .build();
 
-                        var future = sqsClient.receiveMessage(receiveRequest);
+                    try {
+                        var response = sqsClient.receiveMessage(receiveRequest).get();
 
-                        try {
-                            ReceiveMessageResponse response = future.get();
+                        currentBackoff = POLL_ERROR_BACKOFF_BASE;
 
-                            currentBackoff = POLL_ERROR_BACKOFF_BASE;
+                        if (!response.messages().isEmpty()) {
+                            logger.debug("Received {} message(s) from queue '{}'.", response.messages().size(), renderedQueueUrl);
+                        }
 
-                            if (!response.messages().isEmpty()) {
-                                logger.debug("Received {} message(s) from queue '{}'.", response.messages().size(), renderedQueueUrl);
-                            }
-
-                            emitAndDelete(fluxSink, sqsClient, renderedQueueUrl, response.messages(), rAutoDelete, rSerdeType, logger);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            isActive.set(false); // proactively stop polling
-                        } catch (ExecutionException e) {
-                            var cause = e.getCause() != null ? e.getCause() : e;
-                            if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {
-                                logger.error("Fatal SQS error on queue '{}': {}. Stopping trigger.", renderedQueueUrl, cause.getMessage());
-                                signalledError = true;
-                                isActive.set(false);
-                                fluxSink.error(cause);
-                            } else {
-                                logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
-                                sleepInterruptibly(currentBackoff);
-                                currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
-                            }
+                        emitAndDelete(fluxSink, sqsClient, renderedQueueUrl, response.messages(), rAutoDelete, rSerdeType, logger);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        isActive.set(false); // proactively stop polling
+                    } catch (ExecutionException e) {
+                        var cause = e.getCause() != null ? e.getCause() : e;
+                        if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {
+                            logger.error("Fatal SQS error on queue '{}': {}. Stopping trigger.", renderedQueueUrl, cause.getMessage());
+                            signalledError = true;
+                            isActive.set(false);
+                            fluxSink.error(cause);
+                        } else {
+                            logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
+                            sleepInterruptibly(currentBackoff);
+                            currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
                         }
                     }
-                } catch (Throwable e) {
-                    signalledError = true;
-                    fluxSink.error(e);
-                } finally {
-                    if (!signalledError) {
-                        fluxSink.complete();
-                    }
-                    this.waitForTermination.countDown();
                 }
+            } catch (Throwable e) {
+                signalledError = true;
+                fluxSink.error(e);
+            } finally {
+                if (!signalledError) {
+                    fluxSink.complete();
+                }
+                this.waitForTermination.countDown();
             }
-        );
+        });
     }
 
     private void emitAndDelete(
@@ -304,7 +298,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             Object body;
             try {
                 body = serdeType.deserialize(message.body());
-            } catch (java.io.IOException e) {
+            } catch (IOException e) {
                 logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
                 continue;
             }
@@ -362,16 +356,11 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         }
     }
 
-    /**
-     * Sleeps for {@code delay} in {@link #POLL_SLEEP_SLICE}-sized chunks so that
-     * {@link #stop()} (which only sets {@code isActive=false}) cuts the wait short
-     * within one slice rather than blocking for the full backoff duration.
-     */
+    // Sliced so stop() (isActive=false) cuts the wait within one slice, not the full backoff.
     private void sleepInterruptibly(Duration delay) {
         var remaining = delay.toMillis();
-        var slice = POLL_SLEEP_SLICE.toMillis();
         while (isActive.get() && remaining > 0) {
-            var sleepMs = Math.min(remaining, slice);
+            var sleepMs = Math.min(remaining, POLL_SLEEP_SLICE.toMillis());
             try {
                 Thread.sleep(sleepMs);
             } catch (InterruptedException e) {
@@ -389,9 +378,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private static boolean isFatal(SqsException ex) {
         var details = ex.awsErrorDetails();
-        if (details == null) {
-            return false;
-        }
-        return FATAL_ERROR_CODES.contains(details.errorCode());
+        return details != null && FATAL_ERROR_CODES.contains(details.errorCode());
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -325,8 +325,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                     isActive.set(false);
                     break;
                 } catch (ExecutionException de) {
-                    // Accept at-least-once redelivery rather than mixing delete
-                    // failures into the receive-error/backoff path.
+                    // Accept at-least-once redelivery instead of routing delete failures to backoff.
                     var cause = de.getCause() != null ? de.getCause() : de;
                     logger.warn("Failed to delete SQS message (will be redelivered): {}", cause.getMessage());
                 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -263,7 +263,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                             emitAndDelete(fluxSink, sqsClient, renderedQueueUrl, response.messages(), rAutoDelete, rSerdeType, logger);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
-                            isActive.set(false);
+                            isActive.set(false); // proactively stop polling
                         } catch (ExecutionException e) {
                             var cause = e.getCause() != null ? e.getCause() : e;
                             if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -99,6 +100,11 @@ import io.kestra.core.models.annotations.PluginProperty;
     }
 )
 public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<Message>, SqsConnectionInterface {
+
+    private static final Duration POLL_ERROR_BACKOFF_BASE = Duration.ofSeconds(1);
+    private static final Duration POLL_ERROR_BACKOFF_MAX = Duration.ofSeconds(30);
+    // Slice size for interruptible sleep so stop() is responsive within this window.
+    private static final Duration POLL_SLEEP_SLICE = Duration.ofMillis(200);
 
     private Property<String> queueUrl;
 
@@ -210,38 +216,69 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         return Flux.create(
             fluxSink ->
             {
+                Logger logger = runContext.logger();
                 try (SqsAsyncClient sqsClient = task.asyncClient(runContext, runContext.render(clientRetryMaxAttempts).as(Integer.class).orElseThrow())) {
+                    // Render once before the loop to avoid redundant rendering on every iteration.
+                    var rWaitTimeSeconds = (int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds();
+                    var rMaxNumberOfMessages = runContext.render(maxNumberOfMessage).as(Integer.class).orElseThrow();
+                    var rVisibilityTimeout = runContext.render(visibilityTimeout).as(Integer.class).orElse(30);
+                    var rAutoDelete = runContext.render(autoDelete).as(Boolean.class).orElse(true);
+                    var rSerdeType = runContext.render(serdeType).as(SerdeType.class).orElse(SerdeType.STRING);
+
+                    logger.info("Starting SQS consumption from queue '{}'.", renderedQueueUrl);
+
+                    var currentBackoff = POLL_ERROR_BACKOFF_BASE;
+
                     while (isActive.get()) {
                         ReceiveMessageRequest receiveRequest = ReceiveMessageRequest.builder()
                             .queueUrl(renderedQueueUrl)
-                            .waitTimeSeconds((int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds())
-                            .maxNumberOfMessages(runContext.render(maxNumberOfMessage).as(Integer.class).orElseThrow())
-                            .visibilityTimeout(runContext.render(visibilityTimeout).as(Integer.class).orElse(30))
+                            .waitTimeSeconds(rWaitTimeSeconds)
+                            .maxNumberOfMessages(rMaxNumberOfMessages)
+                            .visibilityTimeout(rVisibilityTimeout)
                             .build();
 
                         final CompletableFuture<ReceiveMessageResponse> future = sqsClient.receiveMessage(receiveRequest);
 
                         try {
                             ReceiveMessageResponse response = future.get();
-                            response.messages().forEach(message -> fluxSink.next(Message.builder().data(message.body()).build()));
 
-                            if (runContext.render(autoDelete).as(Boolean.class).orElse(true)) {
-                                response.messages().forEach(
-                                    message -> sqsClient.deleteMessage(
+                            // Reset backoff after a successful poll cycle.
+                            currentBackoff = POLL_ERROR_BACKOFF_BASE;
+
+                            if (!response.messages().isEmpty()) {
+                                logger.debug("Received {} message(s) from queue '{}'.", response.messages().size(), renderedQueueUrl);
+                            }
+
+                            for (var message : response.messages()) {
+                                try {
+                                    fluxSink.next(Message.builder().data(rSerdeType.deserialize(message.body())).build());
+                                } catch (java.io.IOException e) {
+                                    logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
+                                }
+                            }
+
+                            if (rAutoDelete) {
+                                for (var message : response.messages()) {
+                                    sqsClient.deleteMessage(
                                         DeleteMessageRequest.builder()
                                             .queueUrl(renderedQueueUrl)
                                             .receiptHandle(message.receiptHandle())
                                             .build()
-                                    )
-                                );
+                                    ).get();
+                                }
                             }
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             isActive.set(false); // proactively stop polling
+                        } catch (ExecutionException e) {
+                            // Transient error (connection-pool timeout, throttling, network blip).
+                            // Apply capped exponential backoff to avoid a busy-loop under hard-down endpoints.
+                            var cause = e.getCause() != null ? e.getCause() : e;
+                            logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
+                            sleepInterruptibly(currentBackoff);
+                            currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
                         }
                     }
-                } catch (ExecutionException e) {
-                    fluxSink.error(e.getCause() != null ? e.getCause() : e);
                 } catch (Throwable e) {
                     fluxSink.error(e);
                 } finally {
@@ -279,5 +316,30 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Sleeps for {@code delay} in {@link #POLL_SLEEP_SLICE}-sized chunks so that
+     * {@link #stop()} (which only sets {@code isActive=false}) cuts the wait short
+     * within one slice rather than blocking for the full backoff duration.
+     */
+    private void sleepInterruptibly(Duration delay) {
+        var remaining = delay.toMillis();
+        var slice = POLL_SLEEP_SLICE.toMillis();
+        while (isActive.get() && remaining > 0) {
+            var sleepMs = Math.min(remaining, slice);
+            try {
+                Thread.sleep(sleepMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                isActive.set(false);
+                return;
+            }
+            remaining -= sleepMs;
+        }
+    }
+
+    private static Duration min(Duration a, Duration b) {
+        return a.compareTo(b) <= 0 ? a : b;
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.aws.sqs;
 
 import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -29,6 +30,7 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
@@ -105,6 +107,16 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     private static final Duration POLL_ERROR_BACKOFF_MAX = Duration.ofSeconds(30);
     // Slice size for interruptible sleep so stop() is responsive within this window.
     private static final Duration POLL_SLEEP_SLICE = Duration.ofMillis(200);
+
+    // SQS error codes that indicate a permanent configuration problem, not a transient one.
+    private static final Set<String> FATAL_ERROR_CODES = Set.of(
+        "AWS.SimpleQueueService.NonExistentQueue",
+        "QueueDoesNotExist",
+        "InvalidClientTokenId",
+        "AccessDenied",
+        "AuthFailure",
+        "UnrecognizedClientException"
+    );
 
     private Property<String> queueUrl;
 
@@ -217,6 +229,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             fluxSink ->
             {
                 Logger logger = runContext.logger();
+                // Tracks whether fluxSink.error() was already called so we skip complete() afterward.
+                var signalledError = false;
                 try (SqsAsyncClient sqsClient = task.asyncClient(runContext, runContext.render(clientRetryMaxAttempts).as(Integer.class).orElseThrow())) {
                     // Render once before the loop to avoid redundant rendering on every iteration.
                     var rWaitTimeSeconds = (int) runContext.render(waitTime).as(Duration.class).orElseThrow().toSeconds();
@@ -250,39 +264,64 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                             }
 
                             for (var message : response.messages()) {
+                                // Deserialize: a bad message body must not kill the whole loop.
+                                Object body;
                                 try {
-                                    fluxSink.next(Message.builder().data(rSerdeType.deserialize(message.body())).build());
+                                    body = rSerdeType.deserialize(message.body());
                                 } catch (java.io.IOException e) {
                                     logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
+                                    continue;
                                 }
-                            }
 
-                            if (rAutoDelete) {
-                                for (var message : response.messages()) {
-                                    sqsClient.deleteMessage(
-                                        DeleteMessageRequest.builder()
-                                            .queueUrl(renderedQueueUrl)
-                                            .receiptHandle(message.receiptHandle())
-                                            .build()
-                                    ).get();
+                                fluxSink.next(Message.builder().data(body).build());
+
+                                if (rAutoDelete) {
+                                    try {
+                                        sqsClient.deleteMessage(
+                                            DeleteMessageRequest.builder()
+                                                .queueUrl(renderedQueueUrl)
+                                                .receiptHandle(message.receiptHandle())
+                                                .build()
+                                        ).get();
+                                    } catch (InterruptedException ie) {
+                                        // Restore interrupt flag and shut down cleanly.
+                                        Thread.currentThread().interrupt();
+                                        isActive.set(false);
+                                        break;
+                                    } catch (ExecutionException de) {
+                                        // Accept at-least-once redelivery rather than mixing delete
+                                        // failures into the receive-error/backoff path.
+                                        var cause = de.getCause() != null ? de.getCause() : de;
+                                        logger.warn("Failed to delete SQS message (will be redelivered): {}", cause.getMessage());
+                                    }
                                 }
                             }
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             isActive.set(false); // proactively stop polling
                         } catch (ExecutionException e) {
-                            // Transient error (connection-pool timeout, throttling, network blip).
-                            // Apply capped exponential backoff to avoid a busy-loop under hard-down endpoints.
                             var cause = e.getCause() != null ? e.getCause() : e;
-                            logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
-                            sleepInterruptibly(currentBackoff);
-                            currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
+                            if (cause instanceof SqsException sqsEx && isFatal(sqsEx)) {
+                                logger.error("Fatal SQS error on queue '{}': {}. Stopping trigger.", renderedQueueUrl, cause.getMessage());
+                                signalledError = true;
+                                isActive.set(false);
+                                fluxSink.error(cause);
+                            } else {
+                                // Transient error (connection-pool timeout, throttling, network blip).
+                                // Apply capped exponential backoff to avoid a busy-loop under hard-down endpoints.
+                                logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
+                                sleepInterruptibly(currentBackoff);
+                                currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
+                            }
                         }
                     }
                 } catch (Throwable e) {
+                    signalledError = true;
                     fluxSink.error(e);
                 } finally {
-                    fluxSink.complete();
+                    if (!signalledError) {
+                        fluxSink.complete();
+                    }
                     this.waitForTermination.countDown();
                 }
             }
@@ -341,5 +380,13 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private static Duration min(Duration a, Duration b) {
         return a.compareTo(b) <= 0 ? a : b;
+    }
+
+    private static boolean isFatal(SqsException ex) {
+        var details = ex.awsErrorDetails();
+        if (details == null) {
+            return false;
+        }
+        return FATAL_ERROR_CODES.contains(details.errorCode());
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -292,8 +292,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             try {
                 body = serdeType.deserialize(message.body());
             } catch (IOException e) {
-                logger.warn("Failed to deserialize SQS message body (skipping): {}", e.getMessage());
-                continue;
+                // Emit raw to avoid infinite redelivery: poison messages are deleted, not skipped.
+                logger.warn("Failed to deserialize SQS message body, emitting raw and deleting to avoid a redelivery loop: {}", e.getMessage());
+                body = message.body();
             }
 
             sink.next(Message.builder().data(body).build());

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -259,7 +259,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                         } else {
                             logger.warn("Transient error while polling queue '{}': {}. Retrying in {}.", renderedQueueUrl, cause.getMessage(), currentBackoff);
                             sleepInterruptibly(currentBackoff);
-                            currentBackoff = min(currentBackoff.multipliedBy(2), POLL_ERROR_BACKOFF_MAX);
+                            currentBackoff = currentBackoff.multipliedBy(2);
+                            if (currentBackoff.compareTo(POLL_ERROR_BACKOFF_MAX) > 0) {
+                                currentBackoff = POLL_ERROR_BACKOFF_MAX;
+                            }
                         }
                     }
                 }
@@ -360,10 +363,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             }
             remaining -= sleepMs;
         }
-    }
-
-    private static Duration min(Duration a, Duration b) {
-        return a.compareTo(b) <= 0 ? a : b;
     }
 
     private static boolean isFatal(SqsException ex) {

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -289,15 +289,15 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         SerdeType serdeType,
         Logger logger
     ) {
-        var handles = autoDelete ? new ArrayList<String>(messages.size()) : null;
+        var handles = new ArrayList<String>(messages.size());
 
         for (var message : messages) {
             Object body;
             try {
                 body = serdeType.deserialize(message.body());
             } catch (IOException e) {
-                // Emit raw to avoid infinite redelivery: poison messages are deleted, not skipped.
-                logger.warn("Failed to deserialize SQS message body, emitting raw and deleting to avoid a redelivery loop: {}", e.getMessage());
+                // emit raw so a poison message is delivered once and deleted, not looped on
+                logger.warn("Failed to deserialize SQS message body, emitting raw: {}", e.getMessage());
                 body = message.body();
             }
 
@@ -308,11 +308,11 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             }
         }
 
-        if (handles == null || handles.isEmpty()) {
+        if (handles.isEmpty()) {
             return;
         }
 
-        // One batch covers the whole poll: SQS caps both maxNumberOfMessages and deleteMessageBatch at 10.
+        // one batch covers a poll: SQS caps maxNumberOfMessages and deleteMessageBatch at 10
         var entries = new ArrayList<DeleteMessageBatchRequestEntry>(handles.size());
         for (int i = 0; i < handles.size(); i++) {
             entries.add(DeleteMessageBatchRequestEntry.builder()
@@ -323,27 +323,23 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
         try {
             var response = client.deleteMessageBatch(
-                DeleteMessageBatchRequest.builder()
-                    .queueUrl(queueUrl)
-                    .entries(entries)
-                    .build()
+                DeleteMessageBatchRequest.builder().queueUrl(queueUrl).entries(entries).build()
             ).get();
 
             if (!response.failed().isEmpty()) {
-                // Partial failures cause at-least-once redelivery; log and continue.
-                var failedIds = response.failed().stream()
-                    .map(f -> "id=" + f.id() + " code=" + f.code() + " msg=" + f.message())
-                    .toList();
-                logger.warn("SQS batch delete had {} partial failure(s) (will be redelivered): {}", response.failed().size(), failedIds);
+                // partial failures are redelivered, log and keep polling
+                logger.warn(
+                    "SQS batch delete had {} failure(s), will be redelivered: {}",
+                    response.failed().size(),
+                    response.failed().stream().map(f -> f.id() + " " + f.code()).toList()
+                );
             }
         } catch (InterruptedException ie) {
-            // Restore interrupt flag and shut down cleanly.
             Thread.currentThread().interrupt();
             isActive.set(false);
         } catch (ExecutionException de) {
-            // Accept at-least-once redelivery instead of routing delete failures to backoff.
             var cause = de.getCause() != null ? de.getCause() : de;
-            logger.warn("Failed to delete SQS message batch (will be redelivered): {}", cause.getMessage());
+            logger.warn("Failed to delete SQS message batch, will be redelivered: {}", cause.getMessage());
         }
     }
 

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.aws.sqs;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -107,15 +106,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     private static final Duration POLL_ERROR_BACKOFF_BASE = Duration.ofSeconds(1);
     private static final Duration POLL_ERROR_BACKOFF_MAX = Duration.ofSeconds(30);
     private static final Duration POLL_SLEEP_SLICE = Duration.ofMillis(200);
-
-    private static final Set<String> FATAL_ERROR_CODES = Set.of(
-        "AWS.SimpleQueueService.NonExistentQueue",
-        "QueueDoesNotExist",
-        "InvalidClientTokenId",
-        "AccessDenied",
-        "AuthFailure",
-        "UnrecognizedClientException"
-    );
 
     private Property<String> queueUrl;
 
@@ -377,7 +367,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     }
 
     private static boolean isFatal(SqsException ex) {
-        var details = ex.awsErrorDetails();
-        return details != null && FATAL_ERROR_CODES.contains(details.errorCode());
+        // client-side errors (4xx) other than throttling are config/permission problems that retrying will not fix
+        return ex.statusCode() >= 400 && ex.statusCode() < 500 && !ex.isThrottlingException();
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
@@ -1,8 +1,13 @@
 package io.kestra.plugin.aws.sqs.model;
 
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -18,7 +23,7 @@ public class Message implements io.kestra.core.models.tasks.Output {
     @Schema(title = "The message data.")
     @PluginProperty(dynamic = true, group = "main")
     @NotNull
-    private String data;
+    private Object data;
 
     @Schema(title = "The message group ID.")
     @PluginProperty(dynamic = true, group = "advanced")
@@ -32,12 +37,21 @@ public class Message implements io.kestra.core.models.tasks.Output {
     @PluginProperty(group = "advanced")
     private Integer delaySeconds;
 
-    public SendMessageRequest to(SendMessageRequest.Builder builder, RunContext runContext) throws IllegalVariableEvaluationException {
+    public SendMessageRequest to(SendMessageRequest.Builder builder, RunContext runContext) throws IllegalVariableEvaluationException, IOException {
         return builder
-            .messageBody(runContext.render(data))
+            .messageBody(toMessageBody(runContext))
             .messageGroupId(runContext.render(groupId))
             .messageDeduplicationId(runContext.render(deduplicationId))
             .delaySeconds(delaySeconds)
             .build();
+    }
+
+    private String toMessageBody(RunContext runContext) throws IllegalVariableEvaluationException, JsonProcessingException {
+        if (data instanceof String s) {
+            // preserve Pebble templating for string data
+            return runContext.render(s);
+        }
+        // non-string objects (e.g. parsed JSON from RealtimeTrigger output) are serialized back to JSON
+        return JacksonMapper.ofJson().writeValueAsString(data);
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
@@ -55,10 +55,8 @@ public class Message implements io.kestra.core.models.tasks.Output {
 
     private String toMessageBody(RunContext runContext) throws IllegalVariableEvaluationException, JsonProcessingException {
         if (data instanceof String s) {
-            // preserve Pebble templating for string data
             return runContext.render(s);
         }
-        // non-string objects (e.g. parsed JSON from RealtimeTrigger output) are serialized back to JSON
         return JacksonMapper.ofJson().writeValueAsString(data);
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
@@ -68,6 +68,6 @@ public class Message implements io.kestra.core.models.tasks.Output {
         if (data instanceof String s) {
             return runContext.render(s);
         }
-        return JacksonMapper.ofJson().writeValueAsString(data);
+        return JacksonMapper.ofJson(false).writeValueAsString(data);
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/model/Message.java
@@ -20,8 +20,15 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 @Builder
 @Jacksonized
 public class Message implements io.kestra.core.models.tasks.Output {
-    @Schema(title = "The message data.")
-    @PluginProperty(dynamic = true, group = "main")
+    @Schema(
+        title = "The message data.",
+        description = """
+            Accepts a string (Pebble-templated, e.g. "{{ inputs.payload }}") or a structured value \
+            (map, list) that is serialized to JSON before sending. \
+            String values are rendered at runtime; non-string values are passed through Jackson.\
+            """
+    )
+    @PluginProperty(group = "main")
     @NotNull
     private Object data;
 

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -1,0 +1,82 @@
+package io.kestra.plugin.aws.sqs;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.plugin.aws.sqs.model.Message;
+import io.kestra.plugin.aws.sqs.model.SerdeType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests RealtimeTrigger.publisher() JSON deserialization in isolation,
+ * without starting the full Kestra runner/scheduler to avoid inter-test
+ * message consumption by other active triggers.
+ */
+@KestraTest
+class RealtimeTriggerPublisherTest extends AbstractSqsTest {
+
+    @Test
+    void publisherWithJsonSerdeTypeDeserializesBody() throws Exception {
+        var runContext = runContextFactory.of();
+
+        Publish publish = Publish.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .from(List.of(Message.builder().data("{\"order_id\":\"42\",\"customer\":\"Alice\"}").build()))
+            .build();
+        publish.run(runContext);
+
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id("test-rt-json")
+            .type(RealtimeTrigger.class.getName())
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .serdeType(Property.ofValue(SerdeType.JSON))
+            .build();
+
+        Consume task = Consume.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .serdeType(Property.ofValue(SerdeType.JSON))
+            .build();
+
+        CountDownLatch received = new CountDownLatch(1);
+        var messages = new CopyOnWriteArrayList<Message>();
+
+        trigger.publisher(task, runContext)
+            .subscribe(msg -> {
+                messages.add(msg);
+                received.countDown();
+                trigger.stop();
+            });
+
+        boolean got = received.await(1, TimeUnit.MINUTES);
+        assertThat("timed out waiting for JSON message from publisher", got, is(true));
+        assertThat(messages.size(), is(1));
+        var data = messages.getFirst().getData();
+        assertThat(data, instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        var map = (Map<String, Object>) data;
+        assertThat(map.get("order_id"), is("42"));
+        assertThat(map.get("customer"), is("Alice"));
+    }
+}

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
@@ -148,8 +148,8 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
                 }
                 return realClient.receiveMessage((ReceiveMessageRequest) inv.getArgument(0));
             });
-            when(mockClient.deleteMessage(any(DeleteMessageRequest.class))).thenAnswer(inv ->
-                realClient.deleteMessage((DeleteMessageRequest) inv.getArgument(0))
+            when(mockClient.deleteMessageBatch(any(DeleteMessageBatchRequest.class))).thenAnswer(inv ->
+                realClient.deleteMessageBatch((DeleteMessageBatchRequest) inv.getArgument(0))
             );
 
             RealtimeTrigger trigger = RealtimeTrigger.builder()
@@ -334,6 +334,78 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
                 .maxNumberOfMessages(10)
                 .waitTimeSeconds(2));
             assertThat("queue must be empty after poison message was deleted", remaining.messages().isEmpty(), is(true));
+        }
+    }
+
+    /**
+     * When a single poll returns multiple messages, all of them must be deleted via a single batch
+     * call and the queue must be empty afterward.
+     */
+    @Test
+    @Timeout(60)
+    void multipleMessagesInOnePollAreAllDeletedViaBatch() throws Exception {
+        var runContext = runContextFactory.of();
+
+        // Publish 3 messages so a single poll can return them together.
+        try (var sqsClient = SqsClient.builder()
+            .endpointOverride(java.net.URI.create(endpointUrl()))
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build()) {
+            sqsClient.sendMessage(b -> b.queueUrl(queueUrl()).messageBody("msg-1"));
+            sqsClient.sendMessage(b -> b.queueUrl(queueUrl()).messageBody("msg-2"));
+            sqsClient.sendMessage(b -> b.queueUrl(queueUrl()).messageBody("msg-3"));
+        }
+
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id("test-rt-batch-delete")
+            .type(RealtimeTrigger.class.getName())
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .maxNumberOfMessage(Property.ofValue(10))
+            .autoDelete(Property.ofValue(true))
+            .build();
+
+        Consume task = Consume.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .build();
+
+        CountDownLatch received = new CountDownLatch(3);
+        var messages = new CopyOnWriteArrayList<Message>();
+
+        trigger.publisher(task, runContext)
+            .subscribe(msg -> {
+                messages.add(msg);
+                received.countDown();
+                if (received.getCount() == 0) {
+                    trigger.stop();
+                }
+            });
+
+        boolean got = received.await(1, TimeUnit.MINUTES);
+        assertThat("timed out waiting for all 3 messages", got, is(true));
+        assertThat(messages.size(), is(3));
+
+        // All 3 must have been deleted via the batch path: queue drains to 0.
+        try (var sqsClient = SqsClient.builder()
+            .endpointOverride(java.net.URI.create(endpointUrl()))
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build()) {
+            var remaining = sqsClient.receiveMessage(b -> b
+                .queueUrl(queueUrl())
+                .maxNumberOfMessages(10)
+                .waitTimeSeconds(2));
+            assertThat("queue must be empty after batch delete", remaining.messages().isEmpty(), is(true));
         }
     }
 

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -37,11 +37,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Tests RealtimeTrigger.publisher() JSON deserialization in isolation,
- * without starting the full Kestra runner/scheduler to avoid inter-test
- * message consumption by other active triggers.
- */
 @KestraTest
 class RealtimeTriggerPublisherTest extends AbstractSqsTest {
 

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -2,20 +2,39 @@ package io.kestra.plugin.aws.sqs;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.aws.sqs.model.Message;
 import io.kestra.plugin.aws.sqs.model.SerdeType;
+
+import reactor.core.scheduler.Schedulers;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests RealtimeTrigger.publisher() JSON deserialization in isolation,
@@ -24,6 +43,18 @@ import static org.hamcrest.Matchers.is;
  */
 @KestraTest
 class RealtimeTriggerPublisherTest extends AbstractSqsTest {
+
+    @BeforeEach
+    void purgeQueue() {
+        try (var sqsClient = SqsClient.builder()
+            .endpointOverride(java.net.URI.create(endpointUrl()))
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build()) {
+            sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl()).build());
+        }
+    }
 
     @Test
     void publisherWithJsonSerdeTypeDeserializesBody() throws Exception {
@@ -78,5 +109,151 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
         var map = (Map<String, Object>) data;
         assertThat(map.get("order_id"), is("42"));
         assertThat(map.get("customer"), is("Alice"));
+    }
+
+    /**
+     * A transient receive failure must not terminate the publisher. The loop must
+     * recover and continue polling after the backoff.
+     *
+     * We inject a mock SqsAsyncClient that fails on the first receiveMessage call
+     * (simulating a transient error) and succeeds on subsequent calls by delegating
+     * to a real long-lived client.
+     *
+     * The publisher runs on a separate thread (subscribeOn) so the main test thread
+     * can await the result independently.
+     */
+    @Test
+    @Timeout(30)
+    void transientReceiveErrorDoesNotTerminatePublisher() throws Exception {
+        var runContext = runContextFactory.of();
+
+        // Publish one real message that we expect to receive after the transient failure.
+        Publish publish = Publish.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .from(List.of(Message.builder().data("after-transient").build()))
+            .build();
+        publish.run(runContext);
+
+        var realConsumeTask = Consume.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .build();
+
+        // Keep one real client open for the duration so delegated calls have a live connection pool.
+        var realClient = realConsumeTask.asyncClient(runContext);
+        try {
+            var callCount = new AtomicInteger(0);
+            var mockClient = mock(SqsAsyncClient.class);
+
+            // First call: fail with a transient exception.
+            // Subsequent calls: delegate to the shared real client.
+            when(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(inv -> {
+                int call = callCount.incrementAndGet();
+                if (call == 1) {
+                    var failed = new CompletableFuture<ReceiveMessageResponse>();
+                    failed.completeExceptionally(new RuntimeException("simulated transient network error"));
+                    return failed;
+                }
+                return realClient.receiveMessage((ReceiveMessageRequest) inv.getArgument(0));
+            });
+            when(mockClient.deleteMessage(any(DeleteMessageRequest.class))).thenAnswer(inv ->
+                realClient.deleteMessage((DeleteMessageRequest) inv.getArgument(0))
+            );
+
+            Consume consumeWithMock = new Consume() {
+                @Override
+                public SqsAsyncClient asyncClient(RunContext rc, int retryMaxAttempts)
+                    throws io.kestra.core.exceptions.IllegalVariableEvaluationException {
+                    return mockClient;
+                }
+            };
+
+            RealtimeTrigger trigger = RealtimeTrigger.builder()
+                .id("test-rt-transient")
+                .type(RealtimeTrigger.class.getName())
+                .endpointOverride(Property.ofValue(endpointUrl()))
+                .queueUrl(Property.ofValue(queueUrl()))
+                .region(Property.ofValue(REGION))
+                .accessKeyId(Property.ofValue(ACCESS_KEY))
+                .secretKeyId(Property.ofValue(SECRET_KEY))
+                .build();
+
+            CountDownLatch received = new CountDownLatch(1);
+            var messages = new CopyOnWriteArrayList<Message>();
+
+            // subscribeOn so the publisher loop runs on its own thread, not the test thread.
+            trigger.publisher(consumeWithMock, runContext)
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(msg -> {
+                    messages.add(msg);
+                    received.countDown();
+                    trigger.stop();
+                });
+
+            boolean got = received.await(20, TimeUnit.SECONDS);
+            assertThat("publisher did not recover after transient error", got, is(true));
+            assertThat(messages.getFirst().getData(), is("after-transient"));
+        } finally {
+            realClient.close();
+        }
+    }
+
+    /**
+     * stop() must return promptly even when the trigger is mid-backoff.
+     * The backoff slice is 200 ms; we give stop() 500 ms to complete.
+     */
+    @Test
+    @Timeout(10)
+    void stopReturnsDuringBackoff() throws Exception {
+        var runContext = runContextFactory.of();
+
+        // A mock client that always fails so the publisher enters backoff immediately.
+        var mockClient = mock(SqsAsyncClient.class);
+        when(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(inv -> {
+            var failed = new CompletableFuture<ReceiveMessageResponse>();
+            failed.completeExceptionally(new RuntimeException("always failing"));
+            return failed;
+        });
+
+        Consume consumeWithMock = new Consume() {
+            @Override
+            public SqsAsyncClient asyncClient(RunContext rc, int retryMaxAttempts)
+                throws io.kestra.core.exceptions.IllegalVariableEvaluationException {
+                return mockClient;
+            }
+        };
+
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id("test-rt-stop-backoff")
+            .type(RealtimeTrigger.class.getName())
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .build();
+
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        // Run the publisher on a background thread so the test thread is free to call stop().
+        trigger.publisher(consumeWithMock, runContext)
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(msg -> {}, errors::add);
+
+        // Wait until the publisher has entered the backoff sleep (at least one failure recorded).
+        Thread.sleep(300);
+
+        long stopStart = System.currentTimeMillis();
+        trigger.stop();
+        long elapsed = System.currentTimeMillis() - stopStart;
+
+        // stop() must return well within one full backoff (1 s); 500 ms is a generous bound.
+        assertThat("stop() blocked longer than expected during backoff", elapsed < 500, is(true));
     }
 }

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -112,22 +112,13 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
     }
 
     /**
-     * A transient receive failure must not terminate the publisher. The loop must
-     * recover and continue polling after the backoff.
-     *
-     * We inject a mock SqsAsyncClient that fails on the first receiveMessage call
-     * (simulating a transient error) and succeeds on subsequent calls by delegating
-     * to a real long-lived client.
-     *
-     * The publisher runs on a separate thread (subscribeOn) so the main test thread
-     * can await the result independently.
+     * A transient receive failure must not terminate the publisher; it recovers and keeps delivering.
      */
     @Test
     @Timeout(30)
     void transientReceiveErrorDoesNotTerminatePublisher() throws Exception {
         var runContext = runContextFactory.of();
 
-        // Publish one real message that we expect to receive after the transient failure.
         Publish publish = Publish.builder()
             .endpointOverride(Property.ofValue(endpointUrl()))
             .queueUrl(Property.ofValue(queueUrl()))
@@ -152,8 +143,6 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
             var callCount = new AtomicInteger(0);
             var mockClient = mock(SqsAsyncClient.class);
 
-            // First call: fail with a transient exception.
-            // Subsequent calls: delegate to the shared real client.
             when(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(inv -> {
                 int call = callCount.incrementAndGet();
                 if (call == 1) {
@@ -166,14 +155,6 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
             when(mockClient.deleteMessage(any(DeleteMessageRequest.class))).thenAnswer(inv ->
                 realClient.deleteMessage((DeleteMessageRequest) inv.getArgument(0))
             );
-
-            Consume consumeWithMock = new Consume() {
-                @Override
-                public SqsAsyncClient asyncClient(RunContext rc, int retryMaxAttempts)
-                    throws io.kestra.core.exceptions.IllegalVariableEvaluationException {
-                    return mockClient;
-                }
-            };
 
             RealtimeTrigger trigger = RealtimeTrigger.builder()
                 .id("test-rt-transient")
@@ -188,8 +169,7 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
             CountDownLatch received = new CountDownLatch(1);
             var messages = new CopyOnWriteArrayList<Message>();
 
-            // subscribeOn so the publisher loop runs on its own thread, not the test thread.
-            trigger.publisher(consumeWithMock, runContext)
+            trigger.publisher(consumeWithClient(mockClient), runContext)
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(msg -> {
                     messages.add(msg);
@@ -207,28 +187,18 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
 
     /**
      * stop() must return promptly even when the trigger is mid-backoff.
-     * The backoff slice is 200 ms; we give stop() 500 ms to complete.
      */
     @Test
     @Timeout(10)
     void stopReturnsDuringBackoff() throws Exception {
         var runContext = runContextFactory.of();
 
-        // A mock client that always fails so the publisher enters backoff immediately.
         var mockClient = mock(SqsAsyncClient.class);
         when(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(inv -> {
             var failed = new CompletableFuture<ReceiveMessageResponse>();
             failed.completeExceptionally(new RuntimeException("always failing"));
             return failed;
         });
-
-        Consume consumeWithMock = new Consume() {
-            @Override
-            public SqsAsyncClient asyncClient(RunContext rc, int retryMaxAttempts)
-                throws io.kestra.core.exceptions.IllegalVariableEvaluationException {
-                return mockClient;
-            }
-        };
 
         RealtimeTrigger trigger = RealtimeTrigger.builder()
             .id("test-rt-stop-backoff")
@@ -240,20 +210,26 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
             .secretKeyId(Property.ofValue(SECRET_KEY))
             .build();
 
-        var errors = new CopyOnWriteArrayList<Throwable>();
-        // Run the publisher on a background thread so the test thread is free to call stop().
-        trigger.publisher(consumeWithMock, runContext)
+        trigger.publisher(consumeWithClient(mockClient), runContext)
             .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(msg -> {}, errors::add);
+            .subscribe(msg -> {}, err -> {});
 
-        // Wait until the publisher has entered the backoff sleep (at least one failure recorded).
         Thread.sleep(300);
 
         long stopStart = System.currentTimeMillis();
         trigger.stop();
         long elapsed = System.currentTimeMillis() - stopStart;
 
-        // stop() must return well within one full backoff (1 s); 500 ms is a generous bound.
         assertThat("stop() blocked longer than expected during backoff", elapsed < 500, is(true));
+    }
+
+    private static Consume consumeWithClient(SqsAsyncClient client) {
+        return new Consume() {
+            @Override
+            public SqsAsyncClient asyncClient(RunContext rc, int retryMaxAttempts)
+                throws io.kestra.core.exceptions.IllegalVariableEvaluationException {
+                return client;
+            }
+        };
     }
 }

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -112,7 +112,7 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
     }
 
     /**
-     * A transient receive failure must not terminate the publisher; it recovers and keeps delivering.
+     * A transient receive failure must not terminate the publisher. It recovers and keeps delivering.
      */
     @Test
     @Timeout(30)

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -265,6 +265,78 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
         assertThat(errors.getFirst(), instanceOf(SqsException.class));
     }
 
+    /**
+     * A malformed (non-JSON) message must be emitted with the raw body and then deleted so it
+     * never reappears (poison-message loop prevention).
+     */
+    @Test
+    @Timeout(60)
+    void poisonMessageIsEmittedRawAndDeleted() throws Exception {
+        var runContext = runContextFactory.of();
+
+        // Publish a non-JSON body directly via the AWS SDK to bypass SerdeType serialization.
+        try (var sqsClient = SqsClient.builder()
+            .endpointOverride(java.net.URI.create(endpointUrl()))
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build()) {
+            sqsClient.sendMessage(b -> b.queueUrl(queueUrl()).messageBody("not-json"));
+        }
+
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id("test-rt-poison")
+            .type(RealtimeTrigger.class.getName())
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .serdeType(Property.ofValue(SerdeType.JSON))
+            .autoDelete(Property.ofValue(true))
+            .build();
+
+        Consume task = Consume.builder()
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .serdeType(Property.ofValue(SerdeType.JSON))
+            .autoDelete(Property.ofValue(true))
+            .build();
+
+        CountDownLatch received = new CountDownLatch(1);
+        var messages = new CopyOnWriteArrayList<Message>();
+
+        trigger.publisher(task, runContext)
+            .subscribe(msg -> {
+                messages.add(msg);
+                received.countDown();
+                trigger.stop();
+            });
+
+        boolean got = received.await(1, TimeUnit.MINUTES);
+        assertThat("timed out waiting for poison message", got, is(true));
+        assertThat("exactly one execution must be emitted for the poison message", messages.size(), is(1));
+        assertThat("raw body must be a String", messages.getFirst().getData(), instanceOf(String.class));
+        assertThat("raw body value must match the original payload", messages.getFirst().getData(), is("not-json"));
+
+        // Confirm the message was deleted: queue must be empty after a short drain wait.
+        try (var sqsClient = SqsClient.builder()
+            .endpointOverride(java.net.URI.create(endpointUrl()))
+            .region(Region.of(REGION))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build()) {
+            var remaining = sqsClient.receiveMessage(b -> b
+                .queueUrl(queueUrl())
+                .maxNumberOfMessages(10)
+                .waitTimeSeconds(2));
+            assertThat("queue must be empty after poison message was deleted", remaining.messages().isEmpty(), is(true));
+        }
+    }
+
     private static Consume consumeWithClient(SqsAsyncClient client) {
         return new Consume() {
             @Override

--- a/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
+++ b/src/test/java/io/kestra/plugin/aws/sqs/RealtimeTriggerPublisherTest.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -221,6 +222,52 @@ class RealtimeTriggerPublisherTest extends AbstractSqsTest {
         long elapsed = System.currentTimeMillis() - stopStart;
 
         assertThat("stop() blocked longer than expected during backoff", elapsed < 500, is(true));
+    }
+
+    /**
+     * A 403 (AccessDenied) SqsException must terminate the publisher with onError, not retry.
+     */
+    @Test
+    @Timeout(10)
+    void fatalSqsErrorTerminatesPublisher() throws Exception {
+        var runContext = runContextFactory.of();
+
+        var fatalException = SqsException.builder()
+            .statusCode(403)
+            .message("Access to the resource https://sqs.us-east-1.amazonaws.com/000/q is denied.")
+            .build();
+
+        var mockClient = mock(SqsAsyncClient.class);
+        when(mockClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(inv -> {
+            var failed = new CompletableFuture<ReceiveMessageResponse>();
+            failed.completeExceptionally(fatalException);
+            return failed;
+        });
+
+        RealtimeTrigger trigger = RealtimeTrigger.builder()
+            .id("test-rt-fatal-403")
+            .type(RealtimeTrigger.class.getName())
+            .endpointOverride(Property.ofValue(endpointUrl()))
+            .queueUrl(Property.ofValue(queueUrl()))
+            .region(Property.ofValue(REGION))
+            .accessKeyId(Property.ofValue(ACCESS_KEY))
+            .secretKeyId(Property.ofValue(SECRET_KEY))
+            .build();
+
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var terminated = new CountDownLatch(1);
+
+        trigger.publisher(consumeWithClient(mockClient), runContext)
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(
+                msg -> {},
+                err -> { errors.add(err); terminated.countDown(); },
+                terminated::countDown
+            );
+
+        assertThat("publisher did not terminate after fatal 403", terminated.await(5, TimeUnit.SECONDS), is(true));
+        assertThat("publisher must signal onError for fatal exceptions", errors.size(), is(1));
+        assertThat(errors.getFirst(), instanceOf(SqsException.class));
     }
 
     private static Consume consumeWithClient(SqsAsyncClient client) {


### PR DESCRIPTION
- closes #736

Keeps the SQS RealtimeTrigger polling through transient errors (such as an SQS 503 or a dropped idle connection) instead of silently terminating, so messages keep creating executions.