### PR TITLE
fix: fall back to us-east-1 when building STS client without an explicit region

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/ConnectionUtils.java
+++ b/src/main/java/io/kestra/plugin/aws/ConnectionUtils.java
@@ -92,6 +92,12 @@ public class ConnectionUtils {
         final String regionString = awsClientConfig.region();
         if (regionString != null) {
             builder.applyMutation(stsClientBuilder -> stsClientBuilder.region(Region.of(regionString)));
+        } else {
+            // STS is a global AWS service, but AWS SDK v2 requires an explicit region to build
+            // the endpoint URL. Without one it triggers DefaultAwsRegionProviderChain, which
+            // throws a confusing "Unable to load region" error on non-AWS hosts (e.g. GCP/Azure).
+            // Fall back to us-east-1, the canonical STS global endpoint region.
+            builder.applyMutation(stsClientBuilder -> stsClientBuilder.region(Region.US_EAST_1));
         }
         return builder.build();
     }

--- a/src/test/java/io/kestra/plugin/aws/ConnectionUtilsTest.java
+++ b/src/test/java/io/kestra/plugin/aws/ConnectionUtilsTest.java
@@ -21,4 +21,19 @@ class ConnectionUtilsTest {
             ConnectionUtils.configureClient(config, StsClient.builder());
         });
     }
+
+    @Test
+    void stsClient_shouldNotThrowWhenRegionIsNull() {
+        AbstractConnection.AwsClientConfig config = mock(AbstractConnection.AwsClientConfig.class);
+
+        when(config.region()).thenReturn(null);
+        when(config.stsEndpointOverride()).thenReturn(null);
+        when(config.stsRoleArn()).thenReturn("arn:aws:iam::123456789012:role/TestRole");
+        when(config.stsRoleSessionName()).thenReturn("test-session");
+        when(config.stsRoleExternalId()).thenReturn(null);
+        when(config.stsRoleSessionDuration()).thenReturn(java.time.Duration.ofSeconds(900));
+
+        // Should not throw DefaultAwsRegionProviderChain exception when region is not set
+        assertDoesNotThrow(() -> ConnectionUtils.stsClient(config));
+    }
 }


### PR DESCRIPTION
**Fixes:** #730

**Description:**

When `stsRoleArn` is configured but `region` is not, `ConnectionUtils.stsClient()` was building an `StsClient` without calling `.region()`. AWS SDK v2 then invokes `DefaultAwsRegionProviderChain` — which fails with a confusing internal error on any host that is not running in AWS (no `AWS_REGION` env var, no EC2 metadata service). This caused users running flows on GCP/Azure or bare-metal servers to see a cryptic SDK error even on flows that contained no AWS tasks (via plugin defaults resolution).

STS is a global AWS service. Falling back to `Region.US_EAST_1` when no region is explicitly provided is safe and correct — it resolves to the global STS endpoint (`sts.amazonaws.com`).

**Testing:** Added `stsClient_shouldNotThrowWhenRegionIsNull` unit test to `ConnectionUtilsTest`.