### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30) v2

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
+++ b/src/main/java/io/kestra/plugin/aws/AbstractConnection.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.aws;
 
 import java.time.Duration;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 
@@ -22,8 +23,14 @@ public abstract class AbstractConnection extends Task implements AbstractConnect
     protected Property<Boolean> forcePathStyle;
 
     // Configuration for StaticCredentialsProvider
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> accessKeyId;
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> secretKeyId;
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> sessionToken;
 
     // Configuration for AWS STS AssumeRole

--- a/src/main/java/io/kestra/plugin/aws/ConnectionUtils.java
+++ b/src/main/java/io/kestra/plugin/aws/ConnectionUtils.java
@@ -1,6 +1,8 @@
 package io.kestra.plugin.aws;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Duration;
 
 import org.apache.commons.lang3.StringUtils;
@@ -86,7 +88,9 @@ public class ConnectionUtils {
 
         final String stsEndpointOverride = awsClientConfig.stsEndpointOverride();
         if (StringUtils.isNotBlank(stsEndpointOverride)) {
-            builder.applyMutation(stsClientBuilder -> stsClientBuilder.endpointOverride(URI.create(stsEndpointOverride.trim())));
+            URI stsEndpointUri = URI.create(stsEndpointOverride.trim());
+            rejectLinkLocalMetadataHost(stsEndpointUri);
+            builder.applyMutation(stsClientBuilder -> stsClientBuilder.endpointOverride(stsEndpointUri));
         }
 
         final String regionString = awsClientConfig.region();
@@ -163,8 +167,35 @@ public class ConnectionUtils {
         }
 
         if (StringUtils.isNotBlank(clientConfig.endpointOverride())) {
-            builder.endpointOverride(URI.create(clientConfig.endpointOverride().trim()));
+            URI endpointOverride = URI.create(clientConfig.endpointOverride().trim());
+            rejectLinkLocalMetadataHost(endpointOverride);
+            builder.endpointOverride(endpointOverride);
         }
         return builder;
+    }
+
+    /**
+     * Rejects endpoint overrides that resolve to the 169.254.0.0/16 link-local range, which hosts
+     * cloud provider instance-metadata services (e.g. AWS IMDS at 169.254.169.254). Blocking only this
+     * range prevents SSRF-based credential exfiltration while still allowing legitimate self-hosted
+     * S3-compatible endpoints on RFC-1918 private addresses (e.g. on-prem MinIO).
+     */
+    public static void rejectLinkLocalMetadataHost(final URI endpointOverride) {
+        String host = endpointOverride.getHost();
+        if (host == null) {
+            return;
+        }
+        try {
+            InetAddress address = InetAddress.getByName(host);
+            byte[] octets = address.getAddress();
+            if (octets.length == 4 && (octets[0] & 0xFF) == 169 && (octets[1] & 0xFF) == 254) {
+                throw new IllegalArgumentException(
+                    "Endpoint override '" + endpointOverride + "' resolves to a link-local address (169.254.0.0/16), " +
+                        "which is used by cloud instance-metadata services and is not allowed for security reasons."
+                );
+            }
+        } catch (UnknownHostException e) {
+            // Host doesn't resolve; let the AWS SDK surface the connection error downstream.
+        }
     }
 }

--- a/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/AbstractS3.java
@@ -39,7 +39,9 @@ public interface AbstractS3 extends AbstractConnectionInterface {
                 s3ClientBuilder.region(Region.of(clientConfig.region()));
             }
             if (clientConfig.endpointOverride() != null) {
-                s3ClientBuilder.endpointOverride(URI.create(clientConfig.endpointOverride()));
+                URI endpointOverride = URI.create(clientConfig.endpointOverride());
+                ConnectionUtils.rejectLinkLocalMetadataHost(endpointOverride);
+                s3ClientBuilder.endpointOverride(endpointOverride);
             }
             return s3ClientBuilder.build();
         }

--- a/src/main/java/io/kestra/plugin/aws/s3/Trigger.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/Trigger.java
@@ -111,10 +111,16 @@ public class Trigger extends AbstractTrigger
     @Builder.Default
     private final Duration interval = Duration.ofSeconds(60);
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> accessKeyId;
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> secretKeyId;
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> sessionToken;
 
     protected Property<String> region;

--- a/src/main/java/io/kestra/plugin/aws/s3/files/AbstractS3Files.java
+++ b/src/main/java/io/kestra/plugin/aws/s3/files/AbstractS3Files.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.aws.AbstractConnection;
+import io.kestra.plugin.aws.ConnectionUtils;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -67,7 +68,9 @@ public abstract class AbstractS3Files extends AbstractConnection {
             .region(Region.of(cfg.region()));
 
         if (cfg.stsEndpointOverride() != null) {
-            stsBuilder.endpointOverride(URI.create(cfg.stsEndpointOverride()));
+            URI stsEndpointUri = URI.create(cfg.stsEndpointOverride());
+            ConnectionUtils.rejectLinkLocalMetadataHost(stsEndpointUri);
+            stsBuilder.endpointOverride(stsEndpointUri);
         }
 
         if (cfg.accessKeyId() != null && cfg.secretKeyId() != null) {

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -111,10 +111,16 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private Property<String> queueUrl;
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> accessKeyId;
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> secretKeyId;
 
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> sessionToken;
 
     private Property<String> region;

--- a/src/main/java/io/kestra/plugin/aws/sqs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/Trigger.java
@@ -61,12 +61,18 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     private Property<String> queueUrl;
 
     @Schema(title = "Access key id")
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> accessKeyId;
 
     @Schema(title = "Secret key id")
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> secretKeyId;
 
     @Schema(title = "Session token")
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     private Property<String> sessionToken;
 
     @Schema(title = "Region")


### PR DESCRIPTION
## Summary

Remediates findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

Supersedes #767, which was squash-merged into the stale `master` branch (172 commits behind `main`, the actual default branch) by mistake. This PR targets `main` correctly.

## Findings Fixed

- **[HIGH]** SSRF via user-controlled S3/STS endpoint override (`ConnectionUtils.java`, `s3/AbstractS3.java`, `s3/files/AbstractS3Files.java`)
  - Fix: reject endpoint overrides resolving to the 169.254.0.0/16 link-local range (cloud instance-metadata services) while still allowing legitimate self-hosted S3-compatible endpoints on private IPs (e.g. on-prem MinIO)
- **[HIGH]** `s3.Trigger` credential fields missing `@PluginProperty(secret=true)` / `@ToString.Exclude`
- **[HIGH]** `sqs.Trigger` credential fields missing `@PluginProperty(secret=true)` / `@ToString.Exclude`
- **[HIGH]** `sqs.RealtimeTrigger` credential fields missing `@PluginProperty(secret=true)` / `@ToString.Exclude`
- **[MEDIUM]** `AbstractConnection` credential fields missing `@PluginProperty(secret=true)` / `@ToString.Exclude`

## Findings NOT fixed (false positives — closing as not reproducible)

- **#763** "Unsafe deserialization of arbitrary Java objects from S3 objects" — no `ObjectInputStream` or deserialization code exists anywhere in `s3/Trigger.java`; the trigger only lists/polls S3 object metadata.
- **LOW** "S3 presigned URL expiration allows excessively long-lived URLs" — no `CreatePresignedUrl` class or presigned-URL feature exists in this plugin.

## Testing

- [x] `./gradlew compileJava` passes
- [x] `./gradlew lintPluginDocs` passes (this check is what broke #767 on master — all new `@PluginProperty` annotations use a valid `group`)
- [ ] Full test suite (requires LocalStack, not run in this pass)

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-aws/issues/761
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
