### PR TITLE
docs(sqs): document maxConcurrency and connectionAcquisitionTimeout properties

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/sqs/AbstractSqs.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/AbstractSqs.java
@@ -32,9 +32,21 @@ abstract class AbstractSqs extends AbstractConnection implements SqsConnectionIn
 
     private Property<String> queueUrl;
 
+    @Schema(
+        title = "Maximum concurrent HTTP connections to SQS",
+        description = "Connection pool size for the SQS async client. It caps how many requests to SQS " +
+            "can be in flight at once. It does not limit how many messages are consumed or how fast the " +
+            "queue is drained. Defaults to 50, matching the AWS SDK default. Works together with " +
+            "connectionAcquisitionTimeout, which is how long a caller waits for a free connection."
+    )
     @Builder.Default
     private Property<Integer> maxConcurrency = Property.ofValue(50);
 
+    @Schema(
+        title = "Timeout for acquiring an HTTP connection from the pool",
+        description = "How long the SQS async client waits for a free connection before failing. This " +
+            "applies when all maxConcurrency connections are already in use. Defaults to 5 seconds."
+    )
     @Builder.Default
     private Property<Duration> connectionAcquisitionTimeout = Property.ofValue(Duration.ofSeconds(5));
 

--- a/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/RealtimeTrigger.java
@@ -127,9 +127,21 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private Property<String> endpointOverride;
 
+    @Schema(
+        title = "Maximum concurrent HTTP connections to SQS",
+        description = "Connection pool size for the SQS async client. It caps how many requests to SQS " +
+            "can be in flight at once. It does not limit how many messages are consumed or how fast the " +
+            "queue is drained. Defaults to 50, matching the AWS SDK default. Works together with " +
+            "connectionAcquisitionTimeout, which is how long a caller waits for a free connection."
+    )
     @Builder.Default
     private Property<Integer> maxConcurrency = Property.ofValue(50);
 
+    @Schema(
+        title = "Timeout for acquiring an HTTP connection from the pool",
+        description = "How long the SQS async client waits for a free connection before failing. This " +
+            "applies when all maxConcurrency connections are already in use. Defaults to 5 seconds."
+    )
     @Builder.Default
     private Property<Duration> connectionAcquisitionTimeout = Property.ofValue(Duration.ofSeconds(5));
 

--- a/src/main/java/io/kestra/plugin/aws/sqs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/aws/sqs/Trigger.java
@@ -81,12 +81,22 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     @Schema(title = "Endpoint override")
     private Property<String> endpointOverride;
 
+    @Schema(
+        title = "Maximum concurrent HTTP connections to SQS",
+        description = "Connection pool size for the SQS async client. It caps how many requests to SQS " +
+            "can be in flight at once. It does not limit how many messages are consumed or how fast the " +
+            "queue is drained. Defaults to 50, matching the AWS SDK default. Works together with " +
+            "connectionAcquisitionTimeout, which is how long a caller waits for a free connection."
+    )
     @Builder.Default
-    @Schema(title = "Max concurrency")
     private Property<Integer> maxConcurrency = Property.ofValue(50);
 
+    @Schema(
+        title = "Timeout for acquiring an HTTP connection from the pool",
+        description = "How long the SQS async client waits for a free connection before failing. This " +
+            "applies when all maxConcurrency connections are already in use. Defaults to 5 seconds."
+    )
     @Builder.Default
-    @Schema(title = "Connection acquisition timeout")
     private Property<Duration> connectionAcquisitionTimeout = Property.ofValue(Duration.ofSeconds(5));
 
     @Builder.Default


### PR DESCRIPTION
## Summary

- Added `@Schema` docs to `maxConcurrency` and `connectionAcquisitionTimeout` on `AbstractSqs` and `RealtimeTrigger` (previously undocumented).
- Replaced the title-only `@Schema` on the same two properties in `Trigger` with full descriptions.
- Clarifies `maxConcurrency` is the SQS async client's HTTP connection pool size, not a message-consumption or rate-limit control, per support feedback.

## Test plan

- [x] `./gradlew compileJava` compiles cleanly