### PR TITLE
docs: state connection properties per task instead of plugin defaults

### DIFF
--- a/src/main/java/io/kestra/plugin/aws/dynamodb/PutItem.java
+++ b/src/main/java/io/kestra/plugin/aws/dynamodb/PutItem.java
@@ -80,23 +80,23 @@ import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
                           id: 1
                           flow: "{{ flow.id }}"
                           task: "{{ task.id }}"
+                        tableName: demo
+                        region: "{{ secret('AWS_DEFAULT_REGION') }}"
+                        accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+                        secretKeyId: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
 
                       - id: second_item_as_json
                         type: io.kestra.plugin.aws.dynamodb.PutItem
+                        tableName: demo
+                        region: "{{ secret('AWS_DEFAULT_REGION') }}"
+                        accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+                        secretKeyId: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
                         item: |
                           {
                               "id": 2,
                               "flow": "{{ flow.id }}",
                               "task": "{{ task.id }}"
                           }
-
-                    pluginDefaults:
-                      - type: io.kestra.plugin.aws.dynamodb.PutItem
-                        values:
-                          tableName: demo
-                          region: "{{ secret('AWS_DEFAULT_REGION') }}"
-                          accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
-                          secretKeyId: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
                 """
         )
     }

--- a/src/main/resources/doc/io.kestra.plugin.aws.md
+++ b/src/main/resources/doc/io.kestra.plugin.aws.md
@@ -25,7 +25,7 @@ The [default credentials provider chain](https://docs.aws.amazon.com/sdk-for-jav
 
 ## Common properties
 
-Set `region` on each task or globally using [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults) to avoid repeating it. Most tasks also accept `endpointOverride` for connecting to custom or locally hosted endpoints such as LocalStack.
+Set `region` on each task. Most tasks also accept `endpointOverride` for connecting to custom or locally hosted endpoints such as LocalStack.
 
 ## Tasks
 


### PR DESCRIPTION
Removes references to `pluginDefaults`, which was removed in the latest Kestra
release, from this plugin's documentation. Connection properties are now stated
on each task.

Part of a sweep across the plugin repositories: the docs link to
`kestra.io/docs/workflow-components/plugin-defaults` and the surrounding prose
would otherwise point users at a removed feature and a dead docs page.